### PR TITLE
Increment required pydora version number

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,11 @@ Project resources
 Changelog
 =========
 
+v0.1.1 (UNRELEASED)
+----------------------------------------
+
+- Added ability to make preferred audio quality user-configurable.
+
 v0.1.0 (UNRELEASED)
 ----------------------------------------
 

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 0.18',
         'Pykka >= 1.1',
-        'pydora >= 0.2.2',
+        'pydora >= 0.2.3',
     ],
     test_suite='nose.collector',
     tests_require=[


### PR DESCRIPTION
Version 0.2.3 is required for configurable audio quality support.