### PR TITLE
Fix audio quality selection description.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,13 +41,13 @@ Mopidy-Pandora to your Mopidy configuration file::
     [pandora]
     enabled = true
     api_host = tuner.pandora.com/services/json/
-    partner_encryption_key = 
+    partner_encryption_key =
     partner_decryption_key = 
     partner_username = iphone
     partner_password = 
     partner_device = IP01
     preferred_audio_quality = mediumQuality
-    username = 
+    username =
     password = 
 
 The **api_host** and **partner_** keys can be obtained from:
@@ -55,7 +55,7 @@ The **api_host** and **partner_** keys can be obtained from:
  `pandora-apidoc <http://6xq.net/playground/pandora-apidoc/json/partners/#partners>`_
 
 **preferred_audio_quality** can be one of 'lowQuality', 'mediumQuality' (default), or 'highQuality'. If the preferred
-audio quality is not available for the partner device specified, then the next-highest bitrate stream that Pandora
+audio quality is not available for the partner device specified, then the next-lowest bitrate stream that Pandora
 supports for the chosen device will be used.
 
 Usage


### PR DESCRIPTION
Audio quality selection goes from highest to lowest, depending on what Pandora makes available. This is contrary to what is stated in README.rst at present. 

The logic can be verified at: https://github.com/mcrute/pydora/blob/15f16cbdd5cb2f2c61d9eda2c3118bebbb72d11d/pandora/models/pandora.py#L106-L116