### PR TITLE
Initial implementation of AlwaysOnAPIClient. Fixes issue #7.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,13 @@ Project resources
 Changelog
 =========
 
+v0.1.2 (UNRELEASED)
+----------------------------------------
+
+- Enhancement to handle 'Invalid Auth Token' exceptions when the Pandora session expires after long periods of
+  inactivity. Allows Mopidy-Pandora to run indefinitely on dedicated music servers like the Pi MusicBox.
+- Add configuration option to sort stations alphabetically, instead of by date.
+
 v0.1.1 (UNRELEASED)
 ----------------------------------------
 

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -5,6 +5,7 @@ import urllib
 import pykka
 from mopidy import backend, models
 import pandora
+from mopidy_pandora.pydora import AlwaysOnAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
             "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", 'mediumQuality'),
             "SORT_ORDER": config["sort_order"]
         }
-        self.api = pandora.APIClient.from_settings_dict(settings)
+        self.api = AlwaysOnAPIClient.from_settings_dict(settings)
         self.api.login(username=config["username"], password=config["password"])
 
         self.library = PandoraLibraryProvider(backend=self, sort_order=config["sort_order"])
@@ -42,12 +43,23 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
             self.station_token = station_token
             self.tracks = iter(())
 
-        while True:
-            try:
+        try:
+            track = next(self.tracks)
+            # Check if the track is playable
+            if self.backend.api.playable(track):
+                return track
+            else:
+                # Tracks have expired, retrieve fresh playlist from Pandora
+                self.tracks = self._get_playlist(station_token)
                 return next(self.tracks)
-            except StopIteration:
-                self.tracks = (pandora.models.pandora.PlaylistItem.from_json(self.backend.api, station)
-                               for station in self.backend.api.get_playlist(self.station_token)['items'])
+        except StopIteration:
+            # Played through current playlist, retrieve fresh playlist from Pandora
+            self.tracks = self._get_playlist(station_token)
+            return next(self.tracks)
+
+    def _get_playlist(self, station_token):
+        return (pandora.models.pandora.PlaylistItem.from_json(self.backend.api, station)
+            for station in self.backend.api.get_playlist(station_token)['items'])
 
     def change_track(self, track):
         track_uri = PandoraUri.parse(track.uri)

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -4,7 +4,6 @@ import logging
 import urllib
 import pykka
 from mopidy import backend, models
-import pandora
 from mopidy_pandora.pydora import AlwaysOnAPIClient
 
 logger = logging.getLogger(__name__)
@@ -15,20 +14,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
 
     def __init__(self, config, audio):
         super(PandoraBackend, self).__init__()
-        config = config['pandora']
-        settings = {
-            "API_HOST": config.get("api_host", 'tuner.pandora.com/services/json/'),
-            "DECRYPTION_KEY": config["partner_decryption_key"],
-            "ENCRYPTION_KEY": config["partner_encryption_key"],
-            "USERNAME": config["partner_username"],
-            "PASSWORD": config["partner_password"],
-            "DEVICE": config["partner_device"],
-            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", 'mediumQuality'),
-            "SORT_ORDER": config["sort_order"]
-        }
-        self.api = AlwaysOnAPIClient.from_settings_dict(settings)
-        self.api.login(username=config["username"], password=config["password"])
-
+        self.api = AlwaysOnAPIClient(config['pandora'])
         self.library = PandoraLibraryProvider(backend=self, sort_order=config["sort_order"])
         self.playback = PandoraPlaybackProvider(audio=audio, backend=self)
 
@@ -50,16 +36,11 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
                 return track
             else:
                 # Tracks have expired, retrieve fresh playlist from Pandora
-                self.tracks = self._get_playlist(station_token)
+                self.tracks = self.backend.api.get_playlist(station_token)
                 return next(self.tracks)
         except StopIteration:
-            # Played through current playlist, retrieve fresh playlist from Pandora
-            self.tracks = self._get_playlist(station_token)
+            self.tracks = self.backend.api.get_playlist(station_token)
             return next(self.tracks)
-
-    def _get_playlist(self, station_token):
-        return (pandora.models.pandora.PlaylistItem.from_json(self.backend.api, station)
-            for station in self.backend.api.get_playlist(station_token)['items'])
 
     def change_track(self, track):
         track_uri = PandoraUri.parse(track.uri)

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -15,7 +15,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
     def __init__(self, config, audio):
         super(PandoraBackend, self).__init__()
         self.api = AlwaysOnAPIClient(config['pandora'])
-        self.library = PandoraLibraryProvider(backend=self, sort_order=config["sort_order"])
+        self.library = PandoraLibraryProvider(backend=self, sort_order=config['pandora']['sort_order'])
         self.playback = PandoraPlaybackProvider(audio=audio, backend=self)
 
 

--- a/mopidy_pandora/pydora.py
+++ b/mopidy_pandora/pydora.py
@@ -1,8 +1,23 @@
-from pandora.models.pandora import Station
+import functools
 import requests
-from pandora import BaseAPIClient, APIClient, PandoraException
+import pandora
 
-class AlwaysOnAPIClient(APIClient):
+
+def authenticated(f):
+    @functools.wraps(f)
+    def with_authentication(self, *args, **kwargs):
+        try:
+            return f(self, *args, **kwargs)
+        except pandora.PandoraException as e:
+            if e.message == "Invalid Auth Token":
+                # Re-authenticate and retry if we lost auth
+                self.authenticate()
+                return f(self, *args, **kwargs)
+            raise
+    return with_authentication
+
+
+class AlwaysOnAPIClient(object):
     """Pydora API Client for Mopidy-Pandora
 
     This API client automatically re-authenticates itself if the Pandora authorization token
@@ -12,90 +27,35 @@ class AlwaysOnAPIClient(APIClient):
     Detects 'Invalid Auth Token' messages from the Pandora server, and repeats the last
     request after logging in to the Pandora server again.
     """
+    def __init__(self, config):
+        self.settings = {
+            "API_HOST": config.get("api_host", 'tuner.pandora.com/services/json/'),
+            "DECRYPTION_KEY": config["partner_decryption_key"],
+            "ENCRYPTION_KEY": config["partner_encryption_key"],
+            "USERNAME": config["partner_username"],
+            "PASSWORD": config["partner_password"],
+            "DEVICE": config["partner_device"],
+            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", 'mediumQuality')
+        }
+        self.username = config["username"]
+        self.password = config["password"]
+        self.authenticate()
 
-    def __init__(self, transport, partner_user, partner_password, device, default_audio_quality=BaseAPIClient.MED_AUDIO_QUALITY):
-        super(AlwaysOnAPIClient,self).__init__(transport, partner_user, partner_password, device, default_audio_quality)
-        self._stations = []
-        self._station_list_checksum = ""
-
-    def login(self, username, password):
-
-        # Store username and password so that client can re-authenticate itself if required.
-        self.username = username
-        self.password = password
-
-        return super(AlwaysOnAPIClient, self).login(username, password)
-
-
-    def re_authenticate(self):
-
-        # Invalidate old tokens to ensure that the pydora transport layer creates new ones
-        self.transport.user_auth_token = None
-        self.transport.partner_auth_token = None
-
-        # Reset sync times for new Pandora session
-        self.transport.start_time = None
-        self.transport.server_sync_time = None
-
-        self.login(self.username, self.password)
-
+    def authenticate(self):
+        self.api = pandora.APIClient.from_settings_dict(self.settings)
+        self.api.login(username=self.username, password=self.password)
 
     def playable(self, track):
-
         # Retrieve header information of the track's audio_url. Status code 200 implies that
         # the URL is valid and that the track is accessible
-        url = track.audio_url
-        r = requests.head(url)
-        if r.status_code == 200:
-            return True
+        r = requests.head(track.audio_url)
+        return r.status_code == 200
 
-        return False
-
-    def _get_station_list(self):
-        if not self._stations:
-            result = self.transport("user.getStationList", includeStationArtUrl=True)
-            self._station_list_checksum = result['checksum']
-            self._stations = [Station.from_json(self, s)
-                for s in result['stations']]
-            return self._stations
-
-        checksum = self.get_station_list_checksum()['checksum']
-
-        if self._station_list_checksum != checksum:
-            # Station list has been changed by another Pandora client, invalidate and fetch new list.
-            self._stations = []
-            self._get_station_list()
-
-        return self._stations
-
-
+    @authenticated
     def get_station_list(self):
+        return self.api.get_station_list()
 
-        try:
-            return self._get_station_list()
-        except PandoraException as e:
-
-            if e.message == "Invalid Auth Token":
-                self.re_authenticate()
-                return self._get_station_list()
-            else:
-                # Exception is not token related, re-throw to be handled elsewhere
-                raise e
-
-
+    @authenticated
     def get_playlist(self, station_token):
-
-        try:
-            return super(AlwaysOnAPIClient, self).get_playlist(station_token)
-        except PandoraException as e:
-
-            if e.message == "Invalid Auth Token":
-                self.re_authenticate()
-                return super(AlwaysOnAPIClient, self).get_playlist(station_token)
-            else:
-                # Exception is not token related, re-throw to be handled elsewhere
-                raise e
-
-    def get_station_list_checksum(self):
-
-        return self.transport("user.getStationListChecksum")
+        return (pandora.models.pandora.PlaylistItem.from_json(self.api, station)
+                for station in self.api.get_playlist(station_token)['items'])

--- a/mopidy_pandora/pydora.py
+++ b/mopidy_pandora/pydora.py
@@ -1,0 +1,101 @@
+from pandora.models.pandora import Station
+import requests
+from pandora import BaseAPIClient, APIClient, PandoraException
+
+class AlwaysOnAPIClient(APIClient):
+    """Pydora API Client for Mopidy-Pandora
+
+    This API client automatically re-authenticates itself if the Pandora authorization token
+    has expired. This ensures that the Mopidy-Pandora extension will always be available,
+    irrespective of how long Mopidy has been running for.
+
+    Detects 'Invalid Auth Token' messages from the Pandora server, and repeats the last
+    request after logging in to the Pandora server again.
+    """
+
+    def __init__(self, transport, partner_user, partner_password, device, default_audio_quality=BaseAPIClient.MED_AUDIO_QUALITY):
+        super(AlwaysOnAPIClient,self).__init__(transport, partner_user, partner_password, device, default_audio_quality)
+        self._stations = []
+        self._station_list_checksum = ""
+
+    def login(self, username, password):
+
+        # Store username and password so that client can re-authenticate itself if required.
+        self.username = username
+        self.password = password
+
+        return super(AlwaysOnAPIClient, self).login(username, password)
+
+
+    def re_authenticate(self):
+
+        # Invalidate old tokens to ensure that the pydora transport layer creates new ones
+        self.transport.user_auth_token = None
+        self.transport.partner_auth_token = None
+
+        # Reset sync times for new Pandora session
+        self.transport.start_time = None
+        self.transport.server_sync_time = None
+
+        self.login(self.username, self.password)
+
+
+    def playable(self, track):
+
+        # Retrieve header information of the track's audio_url. Status code 200 implies that
+        # the URL is valid and that the track is accessible
+        url = track.audio_url
+        r = requests.head(url)
+        if r.status_code == 200:
+            return True
+
+        return False
+
+    def _get_station_list(self):
+        if not self._stations:
+            result = self.transport("user.getStationList", includeStationArtUrl=True)
+            self._station_list_checksum = result['checksum']
+            self._stations = [Station.from_json(self, s)
+                for s in result['stations']]
+            return self._stations
+
+        checksum = self.get_station_list_checksum()['checksum']
+
+        if self._station_list_checksum != checksum:
+            # Station list has been changed by another Pandora client, invalidate and fetch new list.
+            self._stations = []
+            self._get_station_list()
+
+        return self._stations
+
+
+    def get_station_list(self):
+
+        try:
+            return self._get_station_list()
+        except PandoraException as e:
+
+            if e.message == "Invalid Auth Token":
+                self.re_authenticate()
+                return self._get_station_list()
+            else:
+                # Exception is not token related, re-throw to be handled elsewhere
+                raise e
+
+
+    def get_playlist(self, station_token):
+
+        try:
+            return super(AlwaysOnAPIClient, self).get_playlist(station_token)
+        except PandoraException as e:
+
+            if e.message == "Invalid Auth Token":
+                self.re_authenticate()
+                return super(AlwaysOnAPIClient, self).get_playlist(station_token)
+            else:
+                # Exception is not token related, re-throw to be handled elsewhere
+                raise e
+
+    def get_station_list_checksum(self):
+
+        return self.transport("user.getStationListChecksum")

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Mopidy >= 0.18',
         'Pykka >= 1.1',
         'pydora >= 0.2.3',
+        'requests >= 2.5.0'
     ],
     test_suite='nose.collector',
     tests_require=[


### PR DESCRIPTION
Handles 'Invalid Auth Token' messages by logging in to Pandora again, and then repeating the last request.

Also checks audio URLs that have already been retrieved before they are passed back to Mopidy, and requests a new playlist from Pandora if the URL has expired.

New dependency on 'requests' package for checking the audio URL headers - avoids downloading the full track to check if it is still valid.

Increment version number and update documentation.