### PR TITLE
Add configuration parameter to specify station sort order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,8 @@ Mopidy-Pandora to your Mopidy configuration file::
     partner_device = IP01
     preferred_audio_quality = mediumQuality
     username =
-    password = 
+    password =
+    sort_order = date
 
 The **api_host** and **partner_** keys can be obtained from:
 
@@ -57,6 +58,9 @@ The **api_host** and **partner_** keys can be obtained from:
 **preferred_audio_quality** can be one of 'lowQuality', 'mediumQuality' (default), or 'highQuality'. If the preferred
 audio quality is not available for the partner device specified, then the next-lowest bitrate stream that Pandora
 supports for the chosen device will be used.
+
+**sort_order** defaults to the date that the station was added. Use 'A-Z' to display the list of stations in
+ alphabetical order.
 
 Usage
 =====

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -33,6 +33,7 @@ class Extension(ext.Extension):
         schema['password'] = config.Secret()
         schema['preferred_audio_quality'] = config.String(optional=True, choices=['lowQuality', 'mediumQuality',
                                                                                   'highQuality'])
+        schema['sort_order'] = config.String(optional=True, choices=['date', 'A-Z', 'a-z'])
         return schema
 
     def setup(self, registry):

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -123,14 +123,14 @@ class PandoraLibraryProvider(backend.LibraryProvider):
     root_directory = models.Ref.directory(name='Pandora', uri=PandoraUri('directory').uri)
 
     def __init__(self, backend, sort_order):
-        self.sort_order = sort_order
+        self.sort_order = sort_order.upper()
         super(PandoraLibraryProvider, self).__init__(backend)
 
     def browse(self, uri):
         pandora_uri = PandoraUri.parse(uri)
         if pandora_uri.scheme == 'stations':
             stations = self.backend.api.get_station_list()
-            if self.sort_order.upper() == "A-Z":
+            if self.sort_order == "A-Z":
                 stations.sort(key=lambda x: x.name, reverse=False)
             return [models.Ref.directory(name=station.name, uri=StationUri.from_station(station).uri)
                     for station in stations]

--- a/mopidy_pandora/ext.conf
+++ b/mopidy_pandora/ext.conf
@@ -9,3 +9,4 @@ partner_device = IP01
 username = 
 password =
 preferred_audio_quality = mediumQuality
+sort_order = date


### PR DESCRIPTION
Mimics sort order functionality of the Pandora web and mobile clients.

Automatically sort the list of stations either by creation date (the default) or alphabetically.