### PR TITLE
Add support for Mopidy 1.0 and pydora 1.4.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,13 @@ Project resources
 Changelog
 =========
 
+v0.1.3 (UNRELEASED)
+----------------------------------------
+
+- Update to work with release of Mopidy version 1.0
+- Get rid of 'Stations' root directory. Browsing now displays all of the available stations immediately.
+- Fill artist name to improve how tracks are displayed in various Mopidy front ends
+
 v0.1.2 (UNRELEASED)
 ----------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,8 @@ v0.1.3 (UNRELEASED)
 ----------------------------------------
 
 - Update to work with release of Mopidy version 1.0
+- Update to work with pydora version >= 1.4.0: now keeps the Pandora session alive in tha API itself.
+- Implement station list caching to speed up browsing.
 - Get rid of 'Stations' root directory. Browsing now displays all of the available stations immediately.
 - Fill artist name to improve how tracks are displayed in various Mopidy front ends
 

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,7 @@ The **api_host** and **partner_** keys can be obtained from:
 audio quality is not available for the partner device specified, then the next-lowest bitrate stream that Pandora
 supports for the chosen device will be used.
 
-**sort_order** defaults to the date that the station was added. Use 'A-Z' to display the list of stations in
- alphabetical order.
+**sort_order** defaults to the date that the station was added. Use 'A-Z' to display the list of stations in alphabetical order.
 
 Usage
 =====

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -6,7 +6,7 @@ import os
 from mopidy import config, ext
 
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
+from pandora import BaseAPIClient
 from mopidy import config, ext
 
 
@@ -31,8 +32,9 @@ class Extension(ext.Extension):
         schema['partner_device'] = config.String()
         schema['username'] = config.String()
         schema['password'] = config.Secret()
-        schema['preferred_audio_quality'] = config.String(optional=True, choices=['lowQuality', 'mediumQuality',
-                                                                                  'highQuality'])
+        schema['preferred_audio_quality'] = config.String(optional=True, choices=[BaseAPIClient.LOW_AUDIO_QUALITY,
+                                                                                  BaseAPIClient.MED_AUDIO_QUALITY,
+                                                                                  BaseAPIClient.HIGH_AUDIO_QUALITY])
         schema['sort_order'] = config.String(optional=True, choices=['date', 'A-Z', 'a-z'])
         return schema
 

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -23,7 +23,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
             "PARTNER_USER": config["partner_username"],
             "PARTNER_PASSWORD": config["partner_password"],
             "DEVICE": config["partner_device"],
-            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", BaseAPIClient.MED_AUDIO_QUALITY)
+            "AUDIO_QUALITY": config.get("preferred_audio_quality", BaseAPIClient.MED_AUDIO_QUALITY)
         }
         builder = clientbuilder.APIClientBuilder(client_class=MopidyPandoraAPIClient)
         self.api = builder.build_from_settings_dict(settings)

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -2,9 +2,10 @@ from __future__ import unicode_literals
 
 import logging
 import urllib
+from pandora import clientbuilder
 import pykka
 from mopidy import backend, models
-from mopidy_pandora.pydora import AlwaysOnAPIClient
+from mopidy_pandora.pydora import MopidyPandoraAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -14,8 +15,21 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
 
     def __init__(self, config, audio):
         super(PandoraBackend, self).__init__()
-        self.api = AlwaysOnAPIClient(config['pandora'])
-        self.library = PandoraLibraryProvider(backend=self, sort_order=config['pandora']['sort_order'])
+        config = config['pandora']
+        settings = {
+            "API_HOST": config.get("api_host", 'tuner.pandora.com/services/json/'),
+            "DECRYPTION_KEY": config["partner_decryption_key"],
+            "ENCRYPTION_KEY": config["partner_encryption_key"],
+            "PARTNER_USER": config["partner_username"],
+            "PARTNER_PASSWORD": config["partner_password"],
+            "DEVICE": config["partner_device"],
+            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", 'mediumQuality')
+        }
+        builder = clientbuilder.APIClientBuilder(client_class=MopidyPandoraAPIClient)
+        self.api = builder.build_from_settings_dict(settings)
+        self.api.login(config["username"], config["password"])
+
+        self.library = PandoraLibraryProvider(backend=self, sort_order=config['sort_order'])
         self.playback = PandoraPlaybackProvider(audio=audio, backend=self)
 
 
@@ -32,15 +46,15 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
         try:
             track = next(self.tracks)
             # Check if the track is playable
-            if self.backend.api.playable(track):
+            if track.get_is_playable():
                 return track
             else:
                 # Tracks have expired, retrieve fresh playlist from Pandora
-                self.tracks = self.backend.api.get_playlist(station_token)
+                self.tracks = iter(self.backend.api.get_playlist(station_token))
                 return next(self.tracks)
         except StopIteration:
             # Played through current playlist, retrieve fresh playlist from Pandora
-            self.tracks = self.backend.api.get_playlist(station_token)
+            self.tracks = iter(self.backend.api.get_playlist(station_token))
             return next(self.tracks)
 
 

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import logging
 import urllib
-from pandora import clientbuilder
+from pandora import BaseAPIClient, clientbuilder
 import pykka
 from mopidy import backend, models
 from mopidy_pandora.pydora import MopidyPandoraAPIClient
@@ -23,7 +23,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
             "PARTNER_USER": config["partner_username"],
             "PARTNER_PASSWORD": config["partner_password"],
             "DEVICE": config["partner_device"],
-            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", 'mediumQuality')
+            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", BaseAPIClient.MED_AUDIO_QUALITY)
         }
         builder = clientbuilder.APIClientBuilder(client_class=MopidyPandoraAPIClient)
         self.api = builder.build_from_settings_dict(settings)

--- a/mopidy_pandora/pydora.py
+++ b/mopidy_pandora/pydora.py
@@ -15,10 +15,10 @@ class MopidyPandoraAPIClient(pandora.APIClient):
 
         super(MopidyPandoraAPIClient, self).__init__(transport, partner_user, partner_password, device,
                                                      default_audio_quality)
-        self._station_list = None
+        self._station_list = []
 
     def get_station_list(self):
-        if self._station_list is None or not any(self._station_list) or self._station_list.has_changed():
+        if not any(self._station_list) or self._station_list.has_changed():
             self._station_list = super(MopidyPandoraAPIClient, self).get_station_list()
 
         return self._station_list

--- a/mopidy_pandora/pydora.py
+++ b/mopidy_pandora/pydora.py
@@ -15,13 +15,13 @@ class MopidyPandoraAPIClient(pandora.APIClient):
 
         super(MopidyPandoraAPIClient, self).__init__(transport, partner_user, partner_password, device,
                                                      default_audio_quality)
-        self.station_list = None
+        self._station_list = None
 
     def get_station_list(self):
-        if self.station_list is None or not any(self.station_list) or self.station_list.has_changed():
-            self.station_list = super(MopidyPandoraAPIClient, self).get_station_list()
+        if self._station_list is None or not any(self._station_list) or self._station_list.has_changed():
+            self._station_list = super(MopidyPandoraAPIClient, self).get_station_list()
 
-        return self.station_list
+        return self._station_list
 
     def get_station(self, station_token):
         return self.get_station_list()[station_token]

--- a/mopidy_pandora/pydora.py
+++ b/mopidy_pandora/pydora.py
@@ -25,6 +25,3 @@ class MopidyPandoraAPIClient(pandora.APIClient):
 
     def get_station(self, station_token):
         return self.get_station_list()[station_token]
-
-    def get_playlist(self, station_token):
-        return super(MopidyPandoraAPIClient, self).get_playlist(station_token)

--- a/mopidy_pandora/pydora.py
+++ b/mopidy_pandora/pydora.py
@@ -1,61 +1,30 @@
-import functools
-import requests
+import logging
 import pandora
 
-
-def authenticated(f):
-    @functools.wraps(f)
-    def with_authentication(self, *args, **kwargs):
-        try:
-            return f(self, *args, **kwargs)
-        except pandora.PandoraException as e:
-            if e.message == "Invalid Auth Token":
-                # Re-authenticate and retry if we lost auth
-                self.authenticate()
-                return f(self, *args, **kwargs)
-            raise
-    return with_authentication
+logger = logging.getLogger(__name__)
 
 
-class AlwaysOnAPIClient(object):
+class MopidyPandoraAPIClient(pandora.APIClient):
     """Pydora API Client for Mopidy-Pandora
 
-    This API client automatically re-authenticates itself if the Pandora authorization token
-    has expired. This ensures that the Mopidy-Pandora extension will always be available,
-    irrespective of how long Mopidy has been running for.
-
-    Detects 'Invalid Auth Token' messages from the Pandora server, and repeats the last
-    request after logging in to the Pandora server again.
+    This API client implements caching of the station list.
     """
-    def __init__(self, config):
-        self.settings = {
-            "API_HOST": config.get("api_host", 'tuner.pandora.com/services/json/'),
-            "DECRYPTION_KEY": config["partner_decryption_key"],
-            "ENCRYPTION_KEY": config["partner_encryption_key"],
-            "USERNAME": config["partner_username"],
-            "PASSWORD": config["partner_password"],
-            "DEVICE": config["partner_device"],
-            "DEFAULT_AUDIO_QUALITY": config.get("preferred_audio_quality", 'mediumQuality')
-        }
-        self.username = config["username"]
-        self.password = config["password"]
-        self.authenticate()
 
-    def authenticate(self):
-        self.api = pandora.APIClient.from_settings_dict(self.settings)
-        self.api.login(username=self.username, password=self.password)
+    def __init__(self, transport, partner_user, partner_password, device,
+                 default_audio_quality=pandora.BaseAPIClient.MED_AUDIO_QUALITY):
 
-    def playable(self, track):
-        # Retrieve header information of the track's audio_url. Status code 200 implies that
-        # the URL is valid and that the track is accessible
-        r = requests.head(track.audio_url)
-        return r.status_code == 200
+        super(MopidyPandoraAPIClient, self).__init__(transport, partner_user, partner_password, device,
+                                                     default_audio_quality)
+        self.station_list = None
 
-    @authenticated
     def get_station_list(self):
-        return self.api.get_station_list()
+        if self.station_list is None or not any(self.station_list) or self.station_list.has_changed():
+            self.station_list = super(MopidyPandoraAPIClient, self).get_station_list()
 
-    @authenticated
+        return self.station_list
+
+    def get_station(self, station_token):
+        return self.get_station_list()[station_token]
+
     def get_playlist(self, station_token):
-        return (pandora.models.pandora.PlaylistItem.from_json(self.api, station)
-                for station in self.api.get_playlist(station_token)['items'])
+        return super(MopidyPandoraAPIClient, self).get_playlist(station_token)

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ setup(
     include_package_data=True,
     install_requires=[
         'setuptools',
-        'Mopidy >= 0.18',
+        'Mopidy >= 1.0.7',
         'Pykka >= 1.1',
-        'pydora >= 0.2.3',
+        'pydora = 0.2.4',
         'requests >= 2.5.0'
     ],
     test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 1.0.7',
         'Pykka >= 1.1',
-        'pydora = 0.2.4',
+        'pydora == 0.2.4',
         'requests >= 2.5.0'
     ],
     test_suite='nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 1.0.7',
         'Pykka >= 1.1',
-        'pydora == 0.2.4',
+        'pydora >= 1.4.0',
         'requests >= 2.5.0'
     ],
     test_suite='nose.collector',


### PR DESCRIPTION
- Use the new translate_uri() method introduced in Mopidy 1.0
- Update to work with pydora 1.4.0: re-authentication now supported in the API; uses new clientbuilder interface to initialise client from settings dictionary. 
- Implement simple caching of station list to speed up browsing
- Other small code tweaks and minor enhancements to how tracks are displayed

