### PR TITLE
Encode strings sent to urllib.quote to handle Unicode properly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,13 @@ Project resources
 Changelog
 =========
 
+v0.1.4 (UNRELEASED)
+----------------------------------------
+
+- Limit number of consecutive track skips to prevent Mopidy's skip-to-next-on-error behaviour from locking the Pandora user account
+- Better handling of backend exceptions to prevent Mopidy actor crashes
+- Add support for unicode characters in station and track names
+
 v0.1.3 (UNRELEASED)
 ----------------------------------------
 

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -7,7 +7,7 @@ from pandora import BaseAPIClient
 from mopidy import config, ext
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -114,7 +114,7 @@ class PandoraUri(object):
             self.scheme = scheme
 
     def quote(self, value):
-        return urllib.quote(value) if value is not None else ''
+        return urllib.quote(value.encode('utf8')) if value is not None else ''
 
     @property
     def uri(self):
@@ -122,7 +122,7 @@ class PandoraUri(object):
 
     @classmethod
     def parse(cls, uri):
-        parts = [urllib.unquote(p) for p in uri.split(':')]
+        parts = [urllib.unquote(p.decode('utf8')) for p in uri.split(':')]
         uri_cls = cls.SCHEMES.get(parts[1])
         if uri_cls:
             return uri_cls(*parts[2:])

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import urllib
 from pandora import BaseAPIClient, clientbuilder
@@ -114,15 +112,20 @@ class PandoraUri(object):
             self.scheme = scheme
 
     def quote(self, value):
-        return urllib.quote(str(value).encode('utf8')) if value is not None else ''
+        if value is None:
+            value = ''
+
+        if not isinstance(value, basestring):
+            value = str(value)
+        return urllib.quote(value.encode('utf8'))
 
     @property
     def uri(self):
-        return "pandora:{}".format(self.scheme)
+        return "pandora:{}".format(self.quote(self.scheme))
 
     @classmethod
     def parse(cls, uri):
-        parts = [urllib.unquote(str(p).decode('utf8')) for p in uri.split(':')]
+        parts = [urllib.unquote(p).decode('utf8') for p in uri.split(':')]
         uri_cls = cls.SCHEMES.get(parts[1])
         if uri_cls:
             return uri_cls(*parts[2:])

--- a/mopidy_pandora/actor.py
+++ b/mopidy_pandora/actor.py
@@ -114,7 +114,7 @@ class PandoraUri(object):
             self.scheme = scheme
 
     def quote(self, value):
-        return urllib.quote(value.encode('utf8')) if value is not None else ''
+        return urllib.quote(str(value).encode('utf8')) if value is not None else ''
 
     @property
     def uri(self):
@@ -122,7 +122,7 @@ class PandoraUri(object):
 
     @classmethod
     def parse(cls, uri):
-        parts = [urllib.unquote(p.decode('utf8')) for p in uri.split(':')]
+        parts = [urllib.unquote(str(p).decode('utf8')) for p in uri.split(':')]
         uri_cls = cls.SCHEMES.get(parts[1])
         if uri_cls:
             return uri_cls(*parts[2:])


### PR DESCRIPTION
Encode / decode strings passed to and from ```urllib.(un)quote``` to ensure proper handling of URIs that contain unicode characters.

Prevents ```KeyError``` exceptions as per stack trace below:

2015-08-14 15:03:39,206 - WARNING  /usr/lib/python2.7/urllib.py:1268: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  return ''.join(map(quoter, s))

2015-08-14 15:03:39,208 - ERROR    Unhandled exception in Core (urn:uuid:090fe457-4bfc-4af6-bd8d-d8aa2775e62d):
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/pykka/actor.py", line 201, in _actor_loop
    response = self._handle_receive(message)
  File "/usr/local/lib/python2.7/dist-packages/pykka/actor.py", line 295, in _handle_receive
    return callee(*message['args'], **message['kwargs'])
  File "/var/lib/git/mopidy/mopidy/listener.py", line 54, in on_event
    getattr(self, event)(**kwargs)
  File "/var/lib/git/mopidy/mopidy/core/actor.py", line 87, in reached_end_of_stream
    self.playback._on_end_of_track()
  File "/var/lib/git/mopidy/mopidy/core/playback.py", line 232, in _on_end_of_track
    self._change_track(next_tl_track)
  File "/var/lib/git/mopidy/mopidy/core/playback.py", line 208, in _change_track
    self._play(on_error_step=on_error_step)
  File "/var/lib/git/mopidy/mopidy/core/playback.py", line 348, in _play
    backend.playback.change_track(tl_track.track).get() and
  File "/usr/local/lib/python2.7/dist-packages/pykka/threading.py", line 52, in get
    compat.reraise(*self._data['exc_info'])
  File "/usr/local/lib/python2.7/dist-packages/pykka/compat.py", line 12, in reraise
    exec('raise tp, value, tb')
  File "/usr/local/lib/python2.7/dist-packages/pykka/actor.py", line 201, in _actor_loop
    response = self._handle_receive(message)
  File "/usr/local/lib/python2.7/dist-packages/pykka/actor.py", line 295, in _handle_receive
    return callee(*message['args'], **message['kwargs'])
  File "/var/lib/git/mopidy-pandora/mopidy_pandora/actor.py", line 75, in change_track
    next_track = self.get_next_track()
  File "/var/lib/git/mopidy-pandora/mopidy_pandora/actor.py", line 94, in get_next_track
    return models.Track(uri=TrackUri.from_track(track, PandoraUri.parse(self.active_track.uri).index).uri)
  File "/var/lib/git/mopidy-pandora/mopidy_pandora/actor.py", line 187, in uri
    super(TrackUri, self).uri,
  File "/var/lib/git/mopidy-pandora/mopidy_pandora/actor.py", line 166, in uri
    self.quote(self.name),
  File "/var/lib/git/mopidy-pandora/mopidy_pandora/actor.py", line 131, in quote
    return urllib.quote(value) if value is not None else ''
  File "/usr/lib/python2.7/urllib.py", line 1268, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xe9'
2015-08-14 15:03:39,220 - WARNING  Tried to communicate with dead actor.
2015-08-14 15:03:39,236 - WARNING  Tried to communicate with dead actor.
2015-08-14 15:03:39,254 - WARNING  Tried to communicate with dead actor.