### PR TITLE
Feature/thumbs support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
+sudo: false
+
 language: python
 
 python:
   - "2.7_with_system_site_packages"
+
+addons:
+  apt:
+    sources:
+      - mopidy-stable
+    packages:
+      - mopidy
 
 env:
   - TOX_ENV=py27
   - TOX_ENV=flake8
 
 install:
-  - "wget -O - http://apt.mopidy.com/mopidy.gpg | sudo apt-key add -"
-  - "sudo wget -O /etc/apt/sources.list.d/mopidy.list http://apt.mopidy.com/mopidy.list"
-  - "sudo apt-get update || true"
-  - "sudo apt-get install mopidy"
   - "pip install tox"
 
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include LICENSE
 include MANIFEST.in
 include README.rst
 include mopidy_pandora/ext.conf
+include tox.ini
 
 recursive-include tests *.py

--- a/README.rst
+++ b/README.rst
@@ -10,12 +10,12 @@ Mopidy-Pandora
     :target: https://pypi.python.org/pypi/Mopidy-Pandora/
     :alt: Number of PyPI downloads
 
-.. image:: https://img.shields.io/travis/rectalogic/mopidy-pandora/master.png?style=flat
+.. image:: https://img.shields.io/travis/rectalogic/mopidy-pandora/develop.svg?style=flat
     :target: https://travis-ci.org/rectalogic/mopidy-pandora
     :alt: Travis CI build status
 
-.. image:: https://img.shields.io/coveralls/rectalogic/mopidy-pandora/master.svg?style=flat
-   :target: https://coveralls.io/r/rectalogic/mopidy-pandora?branch=master
+.. image:: https://img.shields.io/coveralls/rectalogic/mopidy-pandora/develop.svg?style=flat
+   :target: https://coveralls.io/r/rectalogic/mopidy-pandora?branch=develop
    :alt: Test coverage
 
 Mopidy extension for Pandora
@@ -51,6 +51,13 @@ Mopidy-Pandora to your Mopidy configuration file::
     password =
     sort_order = date
 
+    ### EXPERIMENTAL RATINGS IMPLEMENTATION ###
+    ratings_support_enabled = false
+    double_click_interval = 2.00
+    on_pause_resume_click = thumbs_up
+    on_pause_next_click = thumbs_down
+    on_pause_previous_click = sleep
+
 The **api_host** and **partner_** keys can be obtained from:
 
  `pandora-apidoc <http://6xq.net/playground/pandora-apidoc/json/partners/#partners>`_
@@ -59,14 +66,29 @@ The **api_host** and **partner_** keys can be obtained from:
 audio quality is not available for the partner device specified, then the next-lowest bitrate stream that Pandora
 supports for the chosen device will be used.
 
-**sort_order** defaults to the date that the station was added. Use 'A-Z' to display the list of stations in alphabetical order.
+**sort_order** defaults to the date that the station was added. Use 'A-Z' to display the list of stations in
+alphabetical order.
+
+**EXPERIMENTAL RATINGS IMPLEMENTATION:** use these settings to work around the limitations of the current Mopidy core
+and front-end extensions:
+
+- double_click_interval - successive button clicks that occur within this interval (in seconds) will trigger the ratings functionality.
+- on_pause_resume_click - click pause and then play while a song is playing to apply the rating. Song continues afterwards.
+- on_pause_next_click - click pause and then next in quick succession. Applies rating and skips to next song. You will have to click play again for the next song to start :(
+- on_pause_previous_click - click pause and then previous in quick succession. Applies rating and skips to next song. You will have to click play again for the next song to start :(
 
 Usage
 =====
 
-Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ support to properly support Pandora.
-In the meantime, Mopidy-Pandora represents each Pandora station as a single track playlist.
-Play this track in repeat mode and each time it is played, the next dynamic track in that station will be played.
+Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ and
+`core extensions <https://github.com/mopidy/mopidy/issues/1100>`_ support to properly support Pandora. In the meantime,
+Mopidy-Pandora represents each Pandora station as a separate playlist. Play the playlist **in repeat mode** and each
+time a track is played, the next dynamic track for that Pandora station will be played.
+
+The playlist will consist of a single track unless the experimental ratings support is enabled. With ratings support
+enabled, the playlist will contain three tracks. These are just used to determine whether the user clicked on the
+'previous' or 'next' playback buttons, and all three tracks point to the same dynamic track for that Pandora station
+(i.e. it does not matter which one you select to play).
 
 
 Project resources
@@ -83,17 +105,18 @@ Changelog
 v0.1.5 (UNRELEASED)
 ----------------------------------------
 
-- Audio quality now defaults to 'high'
-- Improved caching to revert to Pandora server if station cannot be found in the local cache
-- Fix to retrieve stations by ID instead of token
-- Add unit tests to increase coverage
+- Add experimental support for rating songs by re-using buttons available in the current front-end Mopidy extensions.
+- Audio quality now defaults to the highest setting.
+- Improved caching to revert to Pandora server if station cannot be found in the local cache.
+- Fix to retrieve stations by ID instead of token.
+- Add unit tests to increase test coverage.
 
 v0.1.4 (UNRELEASED)
 ----------------------------------------
 
-- Limit number of consecutive track skips to prevent Mopidy's skip-to-next-on-error behaviour from locking the Pandora user account
-- Better handling of backend exceptions to prevent Mopidy actor crashes
-- Add support for unicode characters in station and track names
+- Limit number of consecutive track skips to prevent Mopidy's skip-to-next-on-error behaviour from locking the user's Pandora account.
+- Better handling of exceptions that occur in the backend to prevent Mopidy actor crashes.
+- Add support for unicode characters in station and track names.
 
 v0.1.3 (UNRELEASED)
 ----------------------------------------
@@ -102,7 +125,7 @@ v0.1.3 (UNRELEASED)
 - Update to work with pydora version >= 1.4.0: now keeps the Pandora session alive in tha API itself.
 - Implement station list caching to speed up browsing.
 - Get rid of 'Stations' root directory. Browsing now displays all of the available stations immediately.
-- Fill artist name to improve how tracks are displayed in various Mopidy front ends
+- Fill artist name to improve how tracks are displayed in various Mopidy front-end extensions.
 
 v0.1.2 (UNRELEASED)
 ----------------------------------------

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -37,6 +37,11 @@ class Extension(ext.Extension):
                                                                                   BaseAPIClient.MED_AUDIO_QUALITY,
                                                                                   BaseAPIClient.HIGH_AUDIO_QUALITY])
         schema['sort_order'] = config.String(optional=True, choices=['date', 'A-Z', 'a-z'])
+        schema['ratings_support_enabled'] = config.Boolean()
+        schema['double_click_interval'] = config.String()
+        schema['on_pause_resume_click'] = config.String(choices=['thumbs_up', 'thumbs_down', 'sleep'])
+        schema['on_pause_next_click'] = config.String(choices=['thumbs_up', 'thumbs_down', 'sleep'])
+        schema['on_pause_previous_click'] = config.String(choices=['thumbs_up', 'thumbs_down', 'sleep'])
         return schema
 
     def setup(self, registry):

--- a/mopidy_pandora/backend.py
+++ b/mopidy_pandora/backend.py
@@ -9,7 +9,7 @@ import requests
 
 from mopidy_pandora.client import MopidyPandoraAPIClient
 from mopidy_pandora.library import PandoraLibraryProvider
-from mopidy_pandora.playback import PandoraPlaybackProvider
+from mopidy_pandora.playback import PandoraPlaybackProvider, RatingsSupportPlaybackProvider
 from mopidy_pandora.uri import logger
 
 
@@ -30,7 +30,12 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
         self.api = clientbuilder.SettingsDictBuilder(settings, client_class=MopidyPandoraAPIClient).build()
 
         self.library = PandoraLibraryProvider(backend=self, sort_order=self._config['sort_order'])
-        self.playback = PandoraPlaybackProvider(audio=audio, backend=self)
+        self.supports_ratings = False
+        if self._config['ratings_support_enabled']:
+            self.supports_ratings = True
+            self.playback = RatingsSupportPlaybackProvider(audio=audio, backend=self)
+        else:
+            self.playback = PandoraPlaybackProvider(audio=audio, backend=self)
 
         self.uri_schemes = ['pandora']
 

--- a/mopidy_pandora/doubleclick.py
+++ b/mopidy_pandora/doubleclick.py
@@ -41,7 +41,6 @@ class DoubleClickHandler(object):
                 self.process_click(self.on_pause_previous_click, active_track_uri)
 
     def on_resume_click(self, track_uri, time_position):
-        # TODO: also ignore situation where we resume after being paused due to buffering
         if not self.is_double_click() or time_position == 0:
             return
 

--- a/mopidy_pandora/doubleclick.py
+++ b/mopidy_pandora/doubleclick.py
@@ -52,6 +52,7 @@ class DoubleClickHandler(object):
         logger.warning("Calling '%s()' for track with token: %s", method, token)
         func = getattr(self, method)
         func(token)
+        self.click_time = 0
 
     def thumbs_up(self, track_token):
         self.client.add_feedback(track_token, True)

--- a/mopidy_pandora/doubleclick.py
+++ b/mopidy_pandora/doubleclick.py
@@ -1,0 +1,63 @@
+import logging
+
+import time
+
+from mopidy_pandora.library import PandoraUri
+
+logger = logging.getLogger(__name__)
+
+
+class DoubleClickHandler(object):
+    def __init__(self, config, client):
+        self.on_pause_resume_click = config["on_pause_resume_click"]
+        self.on_pause_next_click = config["on_pause_next_click"]
+        self.on_pause_previous_click = config["on_pause_previous_click"]
+        self.double_click_interval = config['double_click_interval']
+        self.client = client
+        self.click_time = 0
+
+    def set_click(self):
+        self.click_time = time.time()
+
+    def is_double_click(self):
+        return time.time() - self.click_time < float(self.double_click_interval)
+
+    def on_change_track(self, active_track_uri, new_track_uri):
+        from mopidy_pandora.uri import PandoraUri
+
+        if not self.is_double_click():
+            return
+
+        # TODO: Won't work if 'shuffle' or 'consume' modes are enabled
+        if active_track_uri is not None:
+
+            new_track_index = int(PandoraUri.parse(new_track_uri).index)
+            active_track_index = int(PandoraUri.parse(active_track_uri).index)
+
+            if new_track_index > active_track_index or new_track_index == 0 and active_track_index == 2:
+                self.process_click(self.on_pause_next_click, active_track_uri)
+
+            elif new_track_index < active_track_index or new_track_index == active_track_index:
+                self.process_click(self.on_pause_previous_click, active_track_uri)
+
+    def on_resume_click(self, track_uri, time_position):
+        # TODO: also ignore situation where we resume after being paused due to buffering
+        if not self.is_double_click() or time_position == 0:
+            return
+
+        self.process_click(self.on_pause_resume_click, track_uri)
+
+    def process_click(self, method, track_uri):
+        token = PandoraUri.parse(track_uri).token
+        logger.warning("Calling '%s()' for track with token: %s", method, token)
+        func = getattr(self, method)
+        func(token)
+
+    def thumbs_up(self, track_token):
+        self.client.add_feedback(track_token, True)
+
+    def thumbs_down(self, track_token):
+        self.client.add_feedback(track_token, False)
+
+    def sleep(self, track_token):
+        self.client.sleep_song(track_token)

--- a/mopidy_pandora/ext.conf
+++ b/mopidy_pandora/ext.conf
@@ -10,3 +10,10 @@ username =
 password =
 preferred_audio_quality = highQuality
 sort_order = date
+
+### EXPERIMENTAL RATINGS IMPLEMENTATION ###
+ratings_support_enabled = false
+double_click_interval = 2.00
+on_pause_resume_click = thumbs_up
+on_pause_next_click = thumbs_down
+on_pause_previous_click = sleep

--- a/mopidy_pandora/library.py
+++ b/mopidy_pandora/library.py
@@ -24,9 +24,17 @@ class PandoraLibraryProvider(backend.LibraryProvider):
 
             pandora_uri = PandoraUri.parse(uri)
 
-            return [models.Ref.track(name="{} (Repeat Track)".format(pandora_uri.name),
-                                     uri=TrackUri(pandora_uri.station_id, pandora_uri.token, pandora_uri.name,
-                                                  pandora_uri.detail_url, pandora_uri.art_url).uri)]
+            tracks = []
+            number_of_tracks = 1
+            if self.backend.supports_ratings:
+                number_of_tracks = 3
+            for i in range(0, number_of_tracks):
+                tracks.append(models.Ref.track(name="{} (Repeat Track)".format(pandora_uri.name),
+                                               uri=TrackUri(pandora_uri.station_id, pandora_uri.token, pandora_uri.name,
+                                                            pandora_uri.detail_url, pandora_uri.art_url,
+                                                            index=str(i)).uri))
+
+            return tracks
 
     def lookup(self, uri):
 

--- a/mopidy_pandora/uri.py
+++ b/mopidy_pandora/uri.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class _PandoraUriMeta(type):
-    def __init__(cls, name, bases, clsdict):  # noqa
+    def __init__(cls, name, bases, clsdict):  # noqa N805
         super(_PandoraUriMeta, cls).__init__(name, bases, clsdict)
         if hasattr(cls, 'scheme'):
             cls.SCHEMES[cls.scheme] = cls
@@ -73,18 +73,20 @@ class StationUri(PandoraUri):
 class TrackUri(StationUri):
     scheme = 'track'
 
-    def __init__(self, station_id, track_token, name, detail_url, art_url, audio_url='none_generated'):
+    def __init__(self, station_id, track_token, name, detail_url, art_url, audio_url='none_generated', index=0):
         super(TrackUri, self).__init__(station_id, track_token, name, detail_url, art_url)
         self.audio_url = audio_url
+        self.index = index
 
     @classmethod
-    def from_track(cls, track):
+    def from_track(cls, track, index=0):
         return TrackUri(track.station_id, track.track_token, track.song_name, track.song_detail_url,
-                        track.album_art_url, track.audio_url)
+                        track.album_art_url, track.audio_url, index)
 
     @property
     def uri(self):
-        return "{}:{}".format(
+        return "{}:{}:{}".format(
             super(TrackUri, self).uri,
             self.quote(self.audio_url),
+            self.quote(self.index),
         )

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,32 @@ from setuptools.command.test import test
 
 
 def get_version(filename):
-    content = open(filename).read()
-    metadata = dict(re.findall("__([a-z]+)__ = '([^']+)'", content))
-    return metadata['version']
+    with open(filename) as fh:
+        metadata = dict(re.findall("__([a-z]+)__ = '([^']+)'", fh.read()))
+        return metadata['version']
+
+
+class Tox(test):
+    user_options = [(b'tox-args=', b'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        test.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        test.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        # import here, cause outside the eggs aren't loaded
+        import tox
+        import shlex
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
 
 
 class Tox(test):

--- a/setup.py
+++ b/setup.py
@@ -35,30 +35,6 @@ class Tox(test):
         errno = tox.cmdline(args=args)
         sys.exit(errno)
 
-
-class Tox(test):
-    user_options = [(b'tox-args=', b'a', "Arguments to pass to tox")]
-
-    def initialize_options(self):
-        test.initialize_options(self)
-        self.tox_args = None
-
-    def finalize_options(self):
-        test.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import tox
-        import shlex
-        args = self.tox_args
-        if args:
-            args = shlex.split(self.tox_args)
-        errno = tox.cmdline(args=args)
-        sys.exit(errno)
-
-
 setup(
     name='Mopidy-Pandora',
     version=get_version('mopidy_pandora/__init__.py'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,9 @@ MOCK_TRACK_AUDIO_MED = "http://mockup.com/medium_quality_audiofile.mp4?..."
 MOCK_TRACK_AUDIO_LOW = "http://mockup.com/low_quality_audiofile.mp4?..."
 MOCK_TRACK_DETAIL_URL = " http://mockup.com/track/detail_url?..."
 MOCK_TRACK_ART_URL = " http://mockup.com/track/art_url?..."
+MOCK_TRACK_INDEX = "1"
 
-MOCK_DEFAULT_AUDIO_QUALITY = "high_quality"
+MOCK_DEFAULT_AUDIO_QUALITY = "highQuality"
 
 
 @pytest.fixture(scope="session")
@@ -47,6 +48,12 @@ def config():
             'password': 'doe',
             'preferred_audio_quality': MOCK_DEFAULT_AUDIO_QUALITY,
             'sort_order': 'date',
+
+            'ratings_support_enabled': True,
+            'double_click_interval': '0.1',
+            'on_pause_resume_click': 'thumbs_up',
+            'on_pause_next_click': 'thumbs_down',
+            'on_pause_previous_click': 'sleep',
         }
     }
 
@@ -55,7 +62,7 @@ def get_backend(config, simulate_request_exceptions=False):
     obj = backend.PandoraBackend(config=config, audio=None)
 
     if simulate_request_exceptions:
-        type(obj.api.transport).__call__ = transport_call_request_exception_mock
+        type(obj.api.transport).__call__ = request_exception_mock
     else:
         # Ensure that we never do an actual call to the Pandora server while
         # running tests
@@ -143,11 +150,6 @@ def get_station_playlist_mock(self):
 
 
 @pytest.fixture(scope="session")
-def get_station_playlist_request_exception_mock(self):
-    raise requests.exceptions.RequestException
-
-
-@pytest.fixture(scope="session")
 def playlist_item_mock():
     return PlaylistItem.from_json(get_backend(
         config()).api, playlist_result_mock()["items"][0])
@@ -173,23 +175,13 @@ def get_station_list_mock(self):
 
 
 @pytest.fixture(scope="session")
-def get_is_playable_request_exception_mock(self):
-    raise requests.exceptions.RequestException
-
-
-@pytest.fixture(scope="session")
-def transport_call_request_exception_mock(self, method, **data):
+def request_exception_mock(self, *args, **kwargs):
     raise requests.exceptions.RequestException
 
 
 @pytest.fixture
 def transport_call_not_implemented_mock(self, method, **data):
     raise TransportCallTestNotImplemented(method + "(" + json.dumps(self.remove_empty_values(data)) + ")")
-
-
-@pytest.fixture(scope="session")
-def login_exception_mock(self, username, password):
-    raise requests.exceptions.RequestException
 
 
 class TransportCallTestNotImplemented(Exception):

--- a/tests/test_doubleclick.py
+++ b/tests/test_doubleclick.py
@@ -1,0 +1,138 @@
+from __future__ import unicode_literals
+
+import time
+
+import conftest
+
+import mock
+
+import pytest
+
+
+from mopidy_pandora.backend import MopidyPandoraAPIClient
+from mopidy_pandora.doubleclick import DoubleClickHandler
+from mopidy_pandora.uri import PandoraUri, TrackUri
+
+
+@pytest.fixture(scope="session")
+def client_mock():
+    client_mock = mock.Mock(spec=MopidyPandoraAPIClient)
+    return client_mock
+
+
+@pytest.fixture
+def handler(config):
+    handler = DoubleClickHandler(config['pandora'], client_mock)
+    add_feedback_mock = mock.PropertyMock()
+    handler.client.add_feedback = add_feedback_mock
+
+    sleep_mock = mock.PropertyMock()
+    handler.client.sleep_song = sleep_mock
+
+    handler.set_click()
+    return handler
+
+
+def test_is_double_click(handler):
+
+    assert handler.is_double_click()
+
+    time.sleep(float(handler.double_click_interval) + 0.1)
+    assert handler.is_double_click() is False
+
+
+def test_on_change_track_forward(config, handler, playlist_item_mock):
+
+    track_0 = TrackUri.from_track(playlist_item_mock, 0).uri
+    track_1 = TrackUri.from_track(playlist_item_mock, 1).uri
+    track_2 = TrackUri.from_track(playlist_item_mock, 2).uri
+
+    process_click_mock = mock.PropertyMock()
+    handler.process_click = process_click_mock
+
+    handler.on_change_track(track_0, track_1)
+    handler.process_click.assert_called_with(config['pandora']['on_pause_next_click'], track_0)
+    handler.on_change_track(track_1, track_2)
+    handler.process_click.assert_called_with(config['pandora']['on_pause_next_click'], track_1)
+    handler.on_change_track(track_2, track_0)
+    handler.process_click.assert_called_with(config['pandora']['on_pause_next_click'], track_2)
+
+
+def test_on_change_track_back(config, handler, playlist_item_mock):
+
+    track_0 = TrackUri.from_track(playlist_item_mock, 0).uri
+    track_1 = TrackUri.from_track(playlist_item_mock, 1).uri
+    track_2 = TrackUri.from_track(playlist_item_mock, 2).uri
+
+    process_click_mock = mock.PropertyMock()
+    handler.process_click = process_click_mock
+
+    handler.on_change_track(track_2, track_1)
+    handler.process_click.assert_called_with(config['pandora']['on_pause_previous_click'], track_2)
+    handler.on_change_track(track_1, track_0)
+    handler.process_click.assert_called_with(config['pandora']['on_pause_previous_click'], track_1)
+    handler.on_change_track(track_0, track_0)
+    handler.process_click.assert_called_with(config['pandora']['on_pause_previous_click'], track_0)
+
+
+def test_on_resume_click_ignored_if_start_of_track(handler, playlist_item_mock):
+
+    process_click_mock = mock.PropertyMock()
+    handler.process_click = process_click_mock
+    handler.on_resume_click(TrackUri.from_track(playlist_item_mock).uri, 0)
+
+    handler.process_click.assert_not_called()
+
+
+def test_on_resume_click(config, handler, playlist_item_mock):
+
+    process_click_mock = mock.PropertyMock()
+    handler.process_click = process_click_mock
+
+    track_uri = TrackUri.from_track(playlist_item_mock).uri
+    handler.on_resume_click(track_uri, 100)
+
+    handler.process_click.assert_called_once_with(config['pandora']['on_pause_resume_click'], track_uri)
+
+
+def test_process_click(config, handler, playlist_item_mock):
+
+    thumbs_up_mock = mock.PropertyMock()
+    thumbs_down_mock = mock.PropertyMock()
+    sleep_mock = mock.PropertyMock()
+
+    handler.thumbs_up = thumbs_up_mock
+    handler.thumbs_down = thumbs_down_mock
+    handler.sleep = sleep_mock
+
+    track_uri = TrackUri.from_track(playlist_item_mock).uri
+
+    handler.process_click(config['pandora']['on_pause_resume_click'], track_uri)
+    handler.process_click(config['pandora']['on_pause_next_click'], track_uri)
+    handler.process_click(config['pandora']['on_pause_previous_click'], track_uri)
+
+    token = PandoraUri.parse(track_uri).token
+    handler.thumbs_up.assert_called_once_with(token)
+    handler.thumbs_down.assert_called_once_with(token)
+    handler.sleep.assert_called_once_with(token)
+
+
+def test_thumbs_up(handler):
+
+    handler.thumbs_up(conftest.MOCK_TRACK_TOKEN)
+
+    handler.client.add_feedback.assert_called_once_with(conftest.MOCK_TRACK_TOKEN, True)
+
+
+def test_thumbs_down(handler):
+
+    handler.thumbs_down(conftest.MOCK_TRACK_TOKEN)
+
+    handler.client.add_feedback.assert_called_once_with(conftest.MOCK_TRACK_TOKEN, False)
+
+
+def test_sleep(handler):
+
+    handler.sleep(conftest.MOCK_TRACK_TOKEN)
+
+    handler.client.sleep_song.assert_called_once_with(conftest.MOCK_TRACK_TOKEN)

--- a/tests/test_doubleclick.py
+++ b/tests/test_doubleclick.py
@@ -41,6 +41,22 @@ def test_is_double_click(handler):
     assert handler.is_double_click() is False
 
 
+def test_no_duplicate_triggers(handler, playlist_item_mock):
+
+    assert handler.is_double_click()
+
+    thumbs_up_mock = mock.PropertyMock()
+    handler.thumbs_up = thumbs_up_mock
+
+    track_uri = TrackUri.from_track(playlist_item_mock).uri
+    handler.on_resume_click(track_uri, 100)
+
+    assert handler.is_double_click() is False
+    handler.on_resume_click(track_uri, 100)
+
+    handler.thumbs_up.assert_called_once_with(PandoraUri.parse(track_uri).token)
+
+
 def test_on_change_track_forward(config, handler, playlist_item_mock):
 
     track_0 = TrackUri.from_track(playlist_item_mock, 0).uri

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -28,6 +28,11 @@ class ExtensionTest(unittest.TestCase):
         self.assertIn('password =', config)
         self.assertIn('preferred_audio_quality = highQuality', config)
         self.assertIn('sort_order = date', config)
+        self.assertIn('ratings_support_enabled = false', config)
+        self.assertIn('double_click_interval = 2.00', config)
+        self.assertIn('on_pause_resume_click = thumbs_up', config)
+        self.assertIn('on_pause_next_click = thumbs_down', config)
+        self.assertIn('on_pause_previous_click = sleep', config)
 
     def test_get_config_schema(self):
         ext = Extension()
@@ -45,6 +50,11 @@ class ExtensionTest(unittest.TestCase):
         self.assertIn('password', schema)
         self.assertIn('preferred_audio_quality', schema)
         self.assertIn('sort_order', schema)
+        self.assertIn('ratings_support_enabled', schema)
+        self.assertIn('double_click_interval', schema)
+        self.assertIn('on_pause_resume_click', schema)
+        self.assertIn('on_pause_next_click', schema)
+        self.assertIn('on_pause_previous_click', schema)
 
     def test_setup(self):
         registry = mock.Mock()

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -91,12 +91,19 @@ def test_browse_track_uri(config, playlist_item_mock, caplog):
 
     results = backend.library.browse(track_uri.uri)
 
+    assert len(results) == 3
+
+    backend.supports_ratings = False
+
+    results = backend.library.browse(track_uri.uri)
     assert len(results) == 1
+
     assert results[0].type == models.Ref.TRACK
     assert results[0].name == "{} (Repeat Track)".format(track_uri.name)
+    assert TrackUri.parse(results[0].uri).index == str(0)
 
     # Track should not have an audio URL at this stage
-    assert results[0].uri.endswith("none_generated")
+    assert TrackUri.parse(results[0].uri).audio_url == "none_generated"
 
     # Also clear reference track's audio URI so that we can compare more easily
     track_uri.audio_url = "none_generated"

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -93,7 +93,8 @@ def test_track_uri_from_track(playlist_item_mock):
         track_uri.quote(conftest.MOCK_TRACK_NAME) + ":" + \
         track_uri.quote(conftest.MOCK_TRACK_DETAIL_URL) + ":" + \
         track_uri.quote(conftest.MOCK_TRACK_ART_URL) + ":" + \
-        track_uri.quote(conftest.MOCK_TRACK_AUDIO_HIGH)
+        track_uri.quote(conftest.MOCK_TRACK_AUDIO_HIGH) + ":" + \
+        track_uri.quote(0)
 
 
 def test_track_uri_parse(playlist_item_mock):


### PR DESCRIPTION
Initial check-in of experimental thumbs support functionality. Please check README.rst for usage details.

The main elements of the implementation consists of the `DoubleClickHandler`, and instantiating either the old `PandoraPlaybackProvider` or new `RatingsSupportPlaybackProvider` depending on whether the experimental features are enabled or not. I was aiming for some sort of pluggable implementation which is easy to separate from the standard solution - not sure if there is a more pythonic way of accomplishing this so would be open to suggestions on how to refine further.

Other minor changes in this PR include the following:
- Merge with the latest Mopidy cookiecutter for creating extensions, which include minor optimisations for the travis build
- Clarifications and updates to the readme file
- Change travis and coveralls badges to point to develop branch (seems to be the general convention on the Mopidy project as well?)
- Refactor some existing test cases and add new ones to increase coverage.