### PR TITLE
Feature: auto-enable repeat mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Mopidy-Pandora to your Mopidy configuration file::
     username =
     password =
     sort_order = date
+    auto_set_repeat = true
 
     ### EXPERIMENTAL EVENT HANDLING IMPLEMENTATION ###
     event_support_enabled = false
@@ -84,8 +85,9 @@ Usage
 
 Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ and
 `core extensions <https://github.com/mopidy/mopidy/issues/1100>`_ support to properly support Pandora. In the meantime,
-Mopidy-Pandora represents each Pandora station as a separate playlist. Play the playlist **in repeat mode** and each
-time a track is played, the next dynamic track for that Pandora station will be played.
+Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist will automatically be played
+ **in repeat mode** unless you set the **auto_set_repeat** config parameter to 'False'. Each time a track is played,
+ the next dynamic track for that Pandora station will be played.
 
 The playlist will consist of a single track unless the experimental ratings support is enabled. With ratings support
 enabled, the playlist will contain three tracks. These are just used to determine whether the user clicked on the
@@ -107,6 +109,7 @@ Changelog
 v0.1.5 (UNRELEASED)
 ----------------------------------------
 
+- Add option to automatically set tracks to repeat when playback starts
 - Add experimental support for rating songs by re-using buttons available in the current front-end Mopidy extensions.
 - Audio quality now defaults to the highest setting.
 - Improved caching to revert to Pandora server if station cannot be found in the local cache.

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Usage
 Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ and
 `core extensions <https://github.com/mopidy/mopidy/issues/1100>`_ support to properly support Pandora. In the meantime,
 Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist needs to be played **in repeat mode**,
-and Mopidy-Pandora will enable this automatically as soon as the first track starts to play unless you set the **auto_set_repeat**
+and Mopidy-Pandora will enable this automatically just before each track is changed unless you set the **auto_set_repeat**
 config parameter to 'false'.
 
 Each time a track is played, the next dynamic track for that Pandora station will be played. The playlist will consist
@@ -110,7 +110,7 @@ Changelog
 v0.1.5 (UNRELEASED)
 ----------------------------------------
 
-- Add option to automatically set tracks to repeat when playback starts
+- Add option to automatically set tracks to play in repeat mode, using Mopidy's 'about-to-finish' callback.
 - Add experimental support for rating songs by re-using buttons available in the current front-end Mopidy extensions.
 - Audio quality now defaults to the highest setting.
 - Improved caching to revert to Pandora server if station cannot be found in the local cache.

--- a/README.rst
+++ b/README.rst
@@ -85,14 +85,15 @@ Usage
 
 Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ and
 `core extensions <https://github.com/mopidy/mopidy/issues/1100>`_ support to properly support Pandora. In the meantime,
-Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist will automatically be played
- **in repeat mode** unless you set the **auto_set_repeat** config parameter to 'False'. Each time a track is played,
- the next dynamic track for that Pandora station will be played.
+Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist needs to be played **in repeat mode**,
+and Mopidy-Pandora will enable this automatically as soon as the first track starts to play unless you set the **auto_set_repeat**
+config parameter to 'false'.
 
-The playlist will consist of a single track unless the experimental ratings support is enabled. With ratings support
-enabled, the playlist will contain three tracks. These are just used to determine whether the user clicked on the
-'previous' or 'next' playback buttons, and all three tracks point to the same dynamic track for that Pandora station
-(i.e. it does not matter which one you select to play).
+Each time a track is played, the next dynamic track for that Pandora station will be played. The playlist will consist
+of a single track unless the experimental ratings support is enabled. With ratings support enabled, the playlist will
+contain three tracks. These are just used to determine whether the user clicked on the 'previous' or 'next' playback
+buttons, and all three tracks point to the same dynamic track for that Pandora station (i.e. it does not matter which
+one you select to play).
 
 
 Project resources

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -37,6 +37,7 @@ class Extension(ext.Extension):
                                                                                   BaseAPIClient.MED_AUDIO_QUALITY,
                                                                                   BaseAPIClient.HIGH_AUDIO_QUALITY])
         schema['sort_order'] = config.String(optional=True, choices=['date', 'A-Z', 'a-z'])
+        schema['auto_set_repeat'] = config.Boolean()
         schema['event_support_enabled'] = config.Boolean()
         schema['double_click_interval'] = config.String()
         schema['on_pause_resume_click'] = config.String(choices=['thumbs_up', 'thumbs_down', 'sleep'])

--- a/mopidy_pandora/backend.py
+++ b/mopidy_pandora/backend.py
@@ -7,6 +7,8 @@ import pykka
 
 import requests
 
+import rpc
+
 from mopidy_pandora.client import MopidyPandoraAPIClient
 from mopidy_pandora.library import PandoraLibraryProvider
 from mopidy_pandora.playback import EventSupportPlaybackProvider, PandoraPlaybackProvider
@@ -30,8 +32,11 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
         self.api = clientbuilder.SettingsDictBuilder(settings, client_class=MopidyPandoraAPIClient).build()
 
         self.library = PandoraLibraryProvider(backend=self, sort_order=self._config['sort_order'])
-        self.supports_events = False
+
         self.auto_set_repeat = self._config['auto_set_repeat']
+        self.rpc_client = rpc.RPCClient(config['http']['hostname'], config['http']['port'])
+
+        self.supports_events = False
         if self._config['event_support_enabled']:
             self.supports_events = True
             self.playback = EventSupportPlaybackProvider(audio=audio, backend=self)

--- a/mopidy_pandora/backend.py
+++ b/mopidy_pandora/backend.py
@@ -31,6 +31,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
 
         self.library = PandoraLibraryProvider(backend=self, sort_order=self._config['sort_order'])
         self.supports_events = False
+        self.auto_set_repeat = self._config['auto_set_repeat']
         if self._config['event_support_enabled']:
             self.supports_events = True
             self.playback = EventSupportPlaybackProvider(audio=audio, backend=self)

--- a/mopidy_pandora/ext.conf
+++ b/mopidy_pandora/ext.conf
@@ -10,6 +10,7 @@ username =
 password =
 preferred_audio_quality = highQuality
 sort_order = date
+auto_set_repeat = true
 
 ### EXPERIMENTAL RATINGS IMPLEMENTATION ###
 event_support_enabled = false

--- a/mopidy_pandora/library.py
+++ b/mopidy_pandora/library.py
@@ -29,7 +29,7 @@ class PandoraLibraryProvider(backend.LibraryProvider):
             if self.backend.supports_events:
                 number_of_tracks = 3
             for i in range(0, number_of_tracks):
-                tracks.append(models.Ref.track(name="{} (Repeat Track)".format(pandora_uri.name),
+                tracks.append(models.Ref.track(name=pandora_uri.name,
                                                uri=TrackUri(pandora_uri.station_id, pandora_uri.token, pandora_uri.name,
                                                             pandora_uri.detail_url, pandora_uri.art_url,
                                                             index=str(i)).uri))
@@ -42,7 +42,7 @@ class PandoraLibraryProvider(backend.LibraryProvider):
 
         if pandora_uri.scheme == TrackUri.scheme:
 
-            return [models.Track(name="{} (Repeat Track)".format(pandora_uri.name), uri=uri,
+            return [models.Track(name=pandora_uri.name, uri=uri,
                                  artists=[models.Artist(name="Pandora")],
                                  album=models.Album(name=pandora_uri.name, uri=pandora_uri.detail_url,
                                                     images=[pandora_uri.art_url]))]

--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -25,7 +25,7 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
     def callback(self):
         # TODO: add gapless playback when it is supported in Mopidy > 1.1
         # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
-        #self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
+        # self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
 
         if self.backend.auto_set_repeat:
             # Make sure that tracks are being played in 'repeat mode'.

--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -18,20 +18,17 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
         self._station = None
         self._station_iter = None
         self.active_track_uri = None
-        # TODO: add callback when gapless playback is supported in Mopidy > 1.1
-        # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
-        # self.audio.set_about_to_finish_callback(self.callback).get()
+        self.audio.set_about_to_finish_callback(self.callback).get()
         self._mpd_client = MPDClient()               # create client object
         self._mpd_client.timeout = 5                 # network timeout in seconds (floats allowed), default: None
 
     def callback(self):
-        self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
+        # TODO: add gapless playback when it is supported in Mopidy > 1.1
+        # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
+        #self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
 
-    def play(self):
-
-        try:
-            return super(PandoraPlaybackProvider, self).play()
-        finally:
+        if self.backend.auto_set_repeat:
+            # Make sure that tracks are being played in 'repeat mode'.
             self._mpd_client.connect("localhost", 6600)  # connect to localhost:6600
             self._mpd_client.repeat(1)
             self._mpd_client.close()                     # send the close command

--- a/mopidy_pandora/rpc.py
+++ b/mopidy_pandora/rpc.py
@@ -1,0 +1,17 @@
+import json
+
+import requests
+
+
+class RPCClient(object):
+    def __init__(self, hostname, port):
+
+        self.url = 'http://' + str(hostname) + ':' + str(port) + '/mopidy/rpc'
+        self.id = 0
+
+    def set_repeat(self):
+
+        self.id += 1
+        params = {'method': 'core.tracklist.set_repeat', 'params': {'value': True}, 'jsonrpc': '2.0', 'id': self.id}
+
+        requests.request('POST', self.url, data=json.dumps(params), headers={'Content-Type': 'application/json'})

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,7 @@ setup(
         'Mopidy >= 1.0.7',
         'Pykka >= 1.1',
         'pydora >= 1.4.0',
-        'requests >= 2.5.0',
-        'python-mpd2 >= 0.5.4'
+        'requests >= 2.5.0'
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ setup(
         'Mopidy >= 1.0.7',
         'Pykka >= 1.1',
         'pydora >= 1.4.0',
-        'requests >= 2.5.0'
+        'requests >= 2.5.0',
+        'python-mpd2 >= 0.5.4'
     ],
     tests_require=['tox'],
     cmdclass={'test': Tox},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def config():
             'password': 'doe',
             'preferred_audio_quality': MOCK_DEFAULT_AUDIO_QUALITY,
             'sort_order': 'date',
+            'auto_set_repeat': True,
 
             'event_support_enabled': True,
             'double_click_interval': '0.1',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def config():
 
 
 def get_backend(config, simulate_request_exceptions=False):
-    obj = backend.PandoraBackend(config=config, audio=None)
+    obj = backend.PandoraBackend(config=config, audio=Mock())
 
     if simulate_request_exceptions:
         type(obj.api.transport).__call__ = request_exception_mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,10 @@ MOCK_DEFAULT_AUDIO_QUALITY = "highQuality"
 @pytest.fixture(scope="session")
 def config():
     return {
+        'http': {
+            'hostname': '127.0.0.1',
+            'port': '6680'
+        },
         'pandora': {
             'api_host': 'test_host',
             'partner_encryption_key': 'test_encryption_key',

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -34,7 +34,7 @@ def test_lookup_of_track_uri(config, playlist_item_mock):
 
     track = results[0]
 
-    assert track.name == "{} (Repeat Track)".format(track_uri.name)
+    assert track.name == track_uri.name
     assert track.uri == track_uri.uri
     assert next(iter(track.artists)).name == "Pandora"
     assert track.album.name == track_uri.name
@@ -99,7 +99,7 @@ def test_browse_track_uri(config, playlist_item_mock, caplog):
     assert len(results) == 1
 
     assert results[0].type == models.Ref.TRACK
-    assert results[0].name == "{} (Repeat Track)".format(track_uri.name)
+    assert results[0].name == track_uri.name
     assert TrackUri.parse(results[0].uri).index == str(0)
 
     # Track should not have an audio URL at this stage


### PR DESCRIPTION
Injects a call to the MPD server to explicitly set repeat mode each time that a new track starts to play.

Introduces new dependency on ```python-mpd2```

Possible workaround for https://github.com/rectalogic/mopidy-pandora/issues/24, for your consideration.