### PR TITLE
Ignore auto_repeat for non-pandora tracks.

### DIFF
--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -26,7 +26,8 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
         # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
         # self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
 
-        self.backend.rpc_client.set_repeat()
+        if self.active_track_uri is not None and self.active_track_uri.startswith("pandora:"):
+            self.backend.rpc_client.set_repeat()
 
     def change_track(self, track):
 

--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -26,7 +26,8 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
         # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
         # self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
 
-        if self.active_track_uri is not None and self.active_track_uri.startswith("pandora:"):
+        uri = self.backend.rpc_client.get_current_track_uri()
+        if uri is not None and uri.startswith("pandora:"):
             self.backend.rpc_client.set_repeat()
 
     def change_track(self, track):

--- a/mopidy_pandora/rpc.py
+++ b/mopidy_pandora/rpc.py
@@ -9,9 +9,21 @@ class RPCClient(object):
         self.url = 'http://' + str(hostname) + ':' + str(port) + '/mopidy/rpc'
         self.id = 0
 
-    def set_repeat(self):
+    def _do_rpc(self, method, params=None):
 
         self.id += 1
-        params = {'method': 'core.tracklist.set_repeat', 'params': {'value': True}, 'jsonrpc': '2.0', 'id': self.id}
+        data = { 'method': method, 'jsonrpc': '2.0', 'id': self.id }
+        if params is not None:
+            data['params'] = params
 
-        requests.request('POST', self.url, data=json.dumps(params), headers={'Content-Type': 'application/json'})
+        return requests.request('POST', self.url, data=json.dumps(data), headers={'Content-Type': 'application/json'})
+
+    def set_repeat(self):
+
+        self._do_rpc('core.tracklist.set_repeat', {'value': True})
+
+    def get_current_track_uri(self):
+
+        response = self._do_rpc('core.playback.get_current_tl_track')
+        return response.json()['result']['track']['uri']
+

--- a/mopidy_pandora/rpc.py
+++ b/mopidy_pandora/rpc.py
@@ -12,7 +12,7 @@ class RPCClient(object):
     def _do_rpc(self, method, params=None):
 
         self.id += 1
-        data = { 'method': method, 'jsonrpc': '2.0', 'id': self.id }
+        data = {'method': method, 'jsonrpc': '2.0', 'id': self.id}
         if params is not None:
             data['params'] = params
 
@@ -26,4 +26,3 @@ class RPCClient(object):
 
         response = self._do_rpc('core.playback.get_current_tl_track')
         return response.json()['result']['track']['uri']
-

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -174,19 +174,17 @@ def test_translate_uri_returns_audio_url(provider):
 
 def test_auto_set_repeat_off_for_non_pandora_uri(provider):
     with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
+        with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="not_a_pandora_uri::::::"):
 
-        provider.active_track_uri = "not_a_pandora_uri::::::"
+            provider.callback()
 
-        provider.callback()
-
-        assert not provider.backend.rpc_client.set_repeat.called
+            assert not provider.backend.rpc_client.set_repeat.called
 
 
 def test_auto_set_repeat_on_for_pandora_uri(provider):
     with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
+        with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="pandora::::::"):
 
-        provider.active_track_uri = "pandora::::::"
+            provider.callback()
 
-        provider.callback()
-
-        provider.backend.rpc_client.set_repeat.assert_called_once_with()
+            provider.backend.rpc_client.set_repeat.assert_called_once_with()

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -15,6 +15,7 @@ from mopidy_pandora import playback
 from mopidy_pandora.backend import MopidyPandoraAPIClient
 
 from mopidy_pandora.playback import PandoraPlaybackProvider
+from mopidy_pandora.rpc import RPCClient
 
 from mopidy_pandora.uri import TrackUri
 
@@ -169,3 +170,23 @@ def test_is_playable_handles_request_exceptions(provider, caplog):
 def test_translate_uri_returns_audio_url(provider):
 
     assert provider.translate_uri("pandora:track:test:::::audio_url") == "audio_url"
+
+
+def test_auto_set_repeat_off_for_non_pandora_uri(provider):
+    with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
+
+        provider.active_track_uri = "not_a_pandora_uri::::::"
+
+        provider.callback()
+
+        assert not provider.backend.rpc_client.set_repeat.called
+
+
+def test_auto_set_repeat_on_for_pandora_uri(provider):
+    with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
+
+        provider.active_track_uri = "pandora::::::"
+
+        provider.callback()
+
+        provider.backend.rpc_client.set_repeat.assert_called_once_with()


### PR DESCRIPTION
Add check to see if a Pandora track is being played before triggering the auto_set_repeat logic.

This is necessary as the the callback appears to be registered against Mopidy's global ```pykka.ThreadingActor```, and the ```about_to_finish_callback``` is called for every type of track played.