### PR TITLE
Enhance/auto set repeat at start

### DIFF
--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -19,13 +19,12 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
         self._station_iter = None
         self.active_track_uri = None
 
-        self.audio.set_about_to_finish_callback(self.callback).get()
-
-    def callback(self):
         # TODO: add gapless playback when it is supported in Mopidy > 1.1
+        # self.audio.set_about_to_finish_callback(self.callback).get()
+
+    # def callback(self):
         # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
         # self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
-        return
 
     def auto_set_repeat(self):
 

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -176,7 +176,7 @@ def test_auto_set_repeat_off_for_non_pandora_uri(provider):
     with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
         with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="not_a_pandora_uri::::::"):
 
-            provider.callback()
+            provider.prepare_change()
 
             assert not provider.backend.rpc_client.set_repeat.called
 
@@ -185,6 +185,6 @@ def test_auto_set_repeat_on_for_pandora_uri(provider):
     with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
         with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="pandora::::::"):
 
-            provider.callback()
+            provider.prepare_change()
 
             provider.backend.rpc_client.set_repeat.assert_called_once_with()


### PR DESCRIPTION
Move auto-set-repeat logic from Mopidy callback to a separate thread. 

This ensures that repeat mode is enabled as soon as the first Pandora track starts playing, rather than waiting for the callback in the last few seconds of the track.

Handles the usecase where the user clicks the back / next button before the end of the first track is reached.