### PR TITLE
Enhance/auto play after doubleclick

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ alphabetical order.
 and web extensions:
 
 - double_click_interval - successive button clicks that occur within this interval (in seconds) will trigger the event.
-- on_pause_resume_click - click pause and then play while a song is playing to trigger the event. Song continues afterwards.
-- on_pause_next_click - click pause and then next in quick succession. Calls event and skips to next song. You will have to click play again for the next song to start :(
-- on_pause_previous_click - click pause and then previous in quick succession. Calls event and skips to next song. You will have to click play again for the next song to start :(
+- on_pause_resume_click - click pause and then play while a song is playing to trigger the event
+- on_pause_next_click - click pause and then next in quick succession. Calls event and skips to next song.
+- on_pause_previous_click - click pause and then previous in quick succession. Calls event and skips to next song.
 
 The supported events are: thumbs_up, thumbs_down, sleep, add_artist_bookmark, add_song_bookmark
 
@@ -86,8 +86,7 @@ Usage
 Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ and
 `core extensions <https://github.com/mopidy/mopidy/issues/1100>`_ support to properly support Pandora. In the meantime,
 Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist needs to be played **in repeat mode**,
-and Mopidy-Pandora will enable this automatically just before each track is changed unless you set the **auto_set_repeat**
-config parameter to 'false'.
+and Mopidy-Pandora will enable this automatically unless you set the **auto_set_repeat** config parameter to 'false'.
 
 Each time a track is played, the next dynamic track for that Pandora station will be played. The playlist will consist
 of a single track unless the experimental ratings support is enabled. With ratings support enabled, the playlist will
@@ -107,10 +106,15 @@ Project resources
 Changelog
 =========
 
+v0.1.6 (UNRELEASED)
+----------------------------------------
+
+- Fix to resume playback after a track has been rated.
+
 v0.1.5 (UNRELEASED)
 ----------------------------------------
 
-- Add option to automatically set tracks to play in repeat mode, using Mopidy's 'about-to-finish' callback.
+- Add option to automatically set tracks to play in repeat mode when Mopidy-Pandora starts.
 - Add experimental support for rating songs by re-using buttons available in the current front-end Mopidy extensions.
 - Audio quality now defaults to the highest setting.
 - Improved caching to revert to Pandora server if station cannot be found in the local cache.

--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,8 @@ v0.1.6 (UNRELEASED)
 ----------------------------------------
 
 - Fix to resume playback after a track has been rated.
-- Changed auto_setup routines to also ensure that 'random' and 'consome' modes are disabled.
-- Optimized auto_setup routines: now only called once and only when the first pandora track starts to play.
+- Changed auto_setup routines to also ensure that 'consume', 'shuffle', and 'single' modes are disabled.
+- Optimized auto_setup routines: now only called once, and only when the first pandora track starts to play.
 
 v0.1.5 (UNRELEASED)
 ----------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Mopidy-Pandora to your Mopidy configuration file::
     username =
     password =
     sort_order = date
-    auto_set_repeat = true
+    auto_setup = true
 
     ### EXPERIMENTAL EVENT HANDLING IMPLEMENTATION ###
     event_support_enabled = false
@@ -74,7 +74,7 @@ alphabetical order.
 and web extensions:
 
 - double_click_interval - successive button clicks that occur within this interval (in seconds) will trigger the event.
-- on_pause_resume_click - click pause and then play while a song is playing to trigger the event
+- on_pause_resume_click - click pause and then play while a song is playing to trigger the event.
 - on_pause_next_click - click pause and then next in quick succession. Calls event and skips to next song.
 - on_pause_previous_click - click pause and then previous in quick succession. Calls event and skips to next song.
 
@@ -85,8 +85,9 @@ Usage
 
 Mopidy needs `dynamic playlist <https://github.com/mopidy/mopidy/issues/620>`_ and
 `core extensions <https://github.com/mopidy/mopidy/issues/1100>`_ support to properly support Pandora. In the meantime,
-Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist needs to be played **in repeat mode**,
-and Mopidy-Pandora will enable this automatically unless you set the **auto_set_repeat** config parameter to 'false'.
+Mopidy-Pandora represents each Pandora station as a separate playlist. The Playlist needs to be played **in repeat mode**
+and **consume**, **shuffle**, and **single** should be turned off. Mopidy-Pandora will set this up automatically unless
+you set the **auto_setup** config parameter to 'false'.
 
 Each time a track is played, the next dynamic track for that Pandora station will be played. The playlist will consist
 of a single track unless the experimental ratings support is enabled. With ratings support enabled, the playlist will
@@ -110,6 +111,8 @@ v0.1.6 (UNRELEASED)
 ----------------------------------------
 
 - Fix to resume playback after a track has been rated.
+- Changed auto_setup routines to also ensure that 'random' and 'consome' modes are disabled.
+- Optimized auto_setup routines: now only called once and only when the first pandora track starts to play.
 
 v0.1.5 (UNRELEASED)
 ----------------------------------------

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -37,7 +37,7 @@ class Extension(ext.Extension):
                                                                                   BaseAPIClient.MED_AUDIO_QUALITY,
                                                                                   BaseAPIClient.HIGH_AUDIO_QUALITY])
         schema['sort_order'] = config.String(optional=True, choices=['date', 'A-Z', 'a-z'])
-        schema['auto_set_repeat'] = config.Boolean()
+        schema['auto_setup'] = config.Boolean()
         schema['event_support_enabled'] = config.Boolean()
         schema['double_click_interval'] = config.String()
         schema['on_pause_resume_click'] = config.String(choices=['thumbs_up', 'thumbs_down', 'sleep'])

--- a/mopidy_pandora/__init__.py
+++ b/mopidy_pandora/__init__.py
@@ -8,7 +8,7 @@ from mopidy import config, ext
 from pandora import BaseAPIClient
 
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy_pandora/backend.py
+++ b/mopidy_pandora/backend.py
@@ -33,7 +33,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
 
         self.library = PandoraLibraryProvider(backend=self, sort_order=self._config['sort_order'])
 
-        self.auto_set_repeat = self._config['auto_set_repeat']
+        self.reset_auto_setup()
         self.rpc_client = rpc.RPCClient(config['http']['hostname'], config['http']['port'])
 
         self.supports_events = False
@@ -50,3 +50,7 @@ class PandoraBackend(pykka.ThreadingActor, backend.Backend):
             self.api.login(self._config["username"], self._config["password"])
         except requests.exceptions.RequestException as e:
             logger.error('Error logging in to Pandora: %s', encoding.locale_decode(e))
+
+    def reset_auto_setup(self):
+        self.auto_setup = self._config['auto_setup']
+        return self.auto_setup

--- a/mopidy_pandora/ext.conf
+++ b/mopidy_pandora/ext.conf
@@ -10,7 +10,7 @@ username =
 password =
 preferred_audio_quality = highQuality
 sort_order = date
-auto_set_repeat = true
+auto_setup = true
 
 ### EXPERIMENTAL RATINGS IMPLEMENTATION ###
 event_support_enabled = false

--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -1,3 +1,5 @@
+from threading import Thread
+
 from mopidy import backend, models
 from mopidy.internal import encoding
 
@@ -17,18 +19,27 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
         self._station_iter = None
         self.active_track_uri = None
 
-        if self.backend.auto_set_repeat:
-            # Make sure that tracks are being played in 'repeat mode'.
-            self.audio.set_about_to_finish_callback(self.callback).get()
-
-    def callback(self):
         # TODO: add gapless playback when it is supported in Mopidy > 1.1
+        # self.audio.set_about_to_finish_callback(self.callback).get()
+
+    # def callback(self):
         # See: https://discuss.mopidy.com/t/has-the-gapless-playback-implementation-been-completed-yet/784/2
         # self.audio.set_uri(self.translate_uri(self.get_next_track())).get()
 
+    def _auto_set_repeat(self):
+
         uri = self.backend.rpc_client.get_current_track_uri()
+
+        # Make sure that tracks are being played in 'repeat mode'.
         if uri is not None and uri.startswith("pandora:"):
             self.backend.rpc_client.set_repeat()
+
+    def prepare_change(self):
+
+        if self.backend.auto_set_repeat:
+            Thread(target=self._auto_set_repeat).start()
+
+        super(PandoraPlaybackProvider, self).prepare_change()
 
     def change_track(self, track):
 
@@ -85,12 +96,25 @@ class EventSupportPlaybackProvider(PandoraPlaybackProvider):
     def change_track(self, track):
 
         self._double_click_handler.on_change_track(self.active_track_uri, track.uri)
-        return super(EventSupportPlaybackProvider, self).change_track(track)
+        return_value = super(EventSupportPlaybackProvider, self).change_track(track)
+
+        if self._double_click_handler.get_click_time() > 0:
+            self._double_click_handler.set_click_time(0)
+            Thread(target=self.backend.rpc_client.resume_playback).start()
+
+        return return_value
 
     def pause(self):
-        self._double_click_handler.set_click()
+
+        if self.get_time_position() > 0:
+            self._double_click_handler.set_click_time()
+
         return super(EventSupportPlaybackProvider, self).pause()
 
     def resume(self):
         self._double_click_handler.on_resume_click(self.active_track_uri, self.get_time_position())
+
+        if self._double_click_handler.get_click_time() > 0:
+            self._double_click_handler.set_click_time(0)
+
         return super(EventSupportPlaybackProvider, self).resume()

--- a/mopidy_pandora/rpc.py
+++ b/mopidy_pandora/rpc.py
@@ -26,3 +26,7 @@ class RPCClient(object):
 
         response = self._do_rpc('core.playback.get_current_tl_track')
         return response.json()['result']['track']['uri']
+
+    def resume_playback(self):
+
+        self._do_rpc('core.playback.resume')

--- a/mopidy_pandora/rpc.py
+++ b/mopidy_pandora/rpc.py
@@ -18,9 +18,21 @@ class RPCClient(object):
 
         return requests.request('POST', self.url, data=json.dumps(data), headers={'Content-Type': 'application/json'})
 
-    def set_repeat(self):
+    def set_repeat(self, value=True):
 
-        self._do_rpc('core.tracklist.set_repeat', {'value': True})
+        self._do_rpc('core.tracklist.set_repeat', {'value': value})
+
+    def set_consume(self, value=True):
+
+        self._do_rpc('core.tracklist.set_consume', {'value': value})
+
+    def set_single(self, value=True):
+
+        self._do_rpc('core.tracklist.set_single', {'value': value})
+
+    def set_random(self, value=True):
+
+        self._do_rpc('core.tracklist.set_random', {'value': value})
 
     def get_current_track_uri(self):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,8 @@ def config():
 def get_backend(config, simulate_request_exceptions=False):
     obj = backend.PandoraBackend(config=config, audio=Mock())
 
+    obj.rpc_client._do_rpc = Mock()
+
     if simulate_request_exceptions:
         type(obj.api.transport).__call__ = request_exception_mock
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def config():
             'password': 'doe',
             'preferred_audio_quality': MOCK_DEFAULT_AUDIO_QUALITY,
             'sort_order': 'date',
-            'auto_set_repeat': True,
+            'auto_setup': True,
 
             'event_support_enabled': True,
             'double_click_interval': '0.1',

--- a/tests/test_doubleclick.py
+++ b/tests/test_doubleclick.py
@@ -39,10 +39,18 @@ def test_is_double_click(handler):
 
     assert handler.is_double_click()
 
-    assert handler.is_double_click(0) is False
+    time.sleep(float(handler.double_click_interval) + 0.1)
+    assert handler.is_double_click() is False
+
+
+def test_is_double_click_resets_click_time(handler):
+
+    assert handler.is_double_click()
 
     time.sleep(float(handler.double_click_interval) + 0.1)
     assert handler.is_double_click() is False
+
+    assert handler.get_click_time() == 0
 
 
 def test_on_change_track_forward(config, handler, playlist_item_mock):
@@ -98,6 +106,19 @@ def test_on_resume_click(config, handler, playlist_item_mock):
         handler.on_resume_click(track_uri, 100)
 
         handler.process_click.assert_called_once_with(config['pandora']['on_pause_resume_click'], track_uri)
+
+
+def test_process_click_resets_click_time(config, handler, playlist_item_mock):
+
+    thumbs_up_mock = mock.PropertyMock()
+
+    handler.thumbs_up = thumbs_up_mock
+
+    track_uri = TrackUri.from_track(playlist_item_mock).uri
+
+    handler.process_click(config['pandora']['on_pause_resume_click'], track_uri)
+
+    assert handler.get_click_time() == 0
 
 
 def test_process_click_resume(config, handler, playlist_item_mock):

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import threading
+
 import conftest
 
 import mock
@@ -48,7 +50,6 @@ def test_change_track_aborts_if_no_track_uri(provider):
 
 def test_pause_starts_double_click_timer(provider):
     with mock.patch.object(PandoraPlaybackProvider, 'get_time_position', return_value=100):
-
         assert provider.backend.supports_events
         assert provider._double_click_handler.get_click_time() == 0
         provider.pause()
@@ -57,7 +58,6 @@ def test_pause_starts_double_click_timer(provider):
 
 def test_pause_does_not_start_timer_at_track_start(provider):
     with mock.patch.object(PandoraPlaybackProvider, 'get_time_position', return_value=0):
-
         assert provider.backend.supports_events
         assert provider._double_click_handler.get_click_time() == 0
         provider.pause()
@@ -66,7 +66,6 @@ def test_pause_does_not_start_timer_at_track_start(provider):
 
 def test_resume_checks_for_double_click(provider):
     with mock.patch.object(PandoraPlaybackProvider, 'get_time_position', return_value=100):
-
         assert provider.backend.supports_events
         is_double_click_mock = mock.PropertyMock()
         process_click_mock = mock.PropertyMock()
@@ -74,11 +73,10 @@ def test_resume_checks_for_double_click(provider):
         provider._double_click_handler.process_click = process_click_mock
         provider.resume()
 
-        provider._double_click_handler.is_double_click.assert_called_once_with(100)
+        provider._double_click_handler.is_double_click.assert_called_once_with()
 
 
 def test_resume_double_click_call(config, provider):
-
     assert provider.backend.supports_events
 
     process_click_mock = mock.PropertyMock()
@@ -91,28 +89,15 @@ def test_resume_double_click_call(config, provider):
                                                                          provider.active_track_uri)
 
 
-def test_resume_resets_click_time(config, provider):
-
-    assert provider.backend.supports_events
-
-    process_click_mock = mock.PropertyMock()
-
-    provider._double_click_handler.process_click = process_click_mock
-    provider._double_click_handler.set_click_time()
-    provider.resume()
-
-    assert provider._double_click_handler.get_click_time() == 0
-
-
 def test_change_track_checks_for_double_click(provider):
     with mock.patch.object(PandoraPlaybackProvider, 'change_track', return_value=True):
         with mock.patch.object(PandoraPlaybackProvider, 'get_time_position', return_value=100):
-
             assert provider.backend.supports_events
             is_double_click_mock = mock.PropertyMock()
             process_click_mock = mock.PropertyMock()
             provider._double_click_handler.is_double_click = is_double_click_mock
             provider._double_click_handler.process_click = process_click_mock
+            provider.backend.rpc_client.resume_playback = mock.PropertyMock()
             provider.change_track(models.Track(uri=TrackUri.from_track(conftest.playlist_item_mock()).uri))
 
             provider._double_click_handler.is_double_click.assert_called_once_with()
@@ -129,6 +114,7 @@ def test_change_track_double_click_call(config, provider, playlist_item_mock):
         process_click_mock = mock.PropertyMock()
 
         provider._double_click_handler.process_click = process_click_mock
+        provider.backend.rpc_client.resume_playback = mock.PropertyMock()
         provider._double_click_handler.set_click_time()
         provider.active_track_uri = track_0
         provider.change_track(models.Track(uri=track_1))
@@ -149,7 +135,6 @@ def test_change_track(audio_mock, provider):
     with mock.patch.object(MopidyPandoraAPIClient, 'get_station', conftest.get_station_mock):
         with mock.patch.object(Station, 'get_playlist', conftest.get_station_playlist_mock):
             with mock.patch.object(PlaylistItem, 'get_is_playable', return_value=True):
-
                 track = models.Track(uri=TrackUri.from_track(conftest.playlist_item_mock()).uri)
 
                 assert provider.change_track(track) is True
@@ -164,7 +149,6 @@ def test_change_track_enforces_skip_limit(provider):
     with mock.patch.object(MopidyPandoraAPIClient, 'get_station', conftest.get_station_mock):
         with mock.patch.object(Station, 'get_playlist', conftest.get_station_playlist_mock):
             with mock.patch.object(PlaylistItem, 'get_is_playable', return_value=False):
-
                 track = models.Track(uri="pandora:track:test::::")
 
                 assert provider.change_track(track) is False
@@ -174,7 +158,6 @@ def test_change_track_enforces_skip_limit(provider):
 def test_change_track_handles_request_exceptions(config, caplog):
     with mock.patch.object(MopidyPandoraAPIClient, 'get_station', conftest.get_station_mock):
         with mock.patch.object(Station, 'get_playlist', conftest.request_exception_mock):
-
             track = models.Track(uri="pandora:track:test::::")
 
             playback = conftest.get_backend(config).playback
@@ -183,46 +166,67 @@ def test_change_track_handles_request_exceptions(config, caplog):
             assert 'Error changing track' in caplog.text()
 
 
-def test_change_track_resets_click_time(config, provider, playlist_item_mock):
+def test_change_track_resumes_playback(provider, playlist_item_mock):
     with mock.patch.object(PandoraPlaybackProvider, 'change_track', return_value=True):
-        assert provider.backend.supports_events
+        with mock.patch.object(RPCClient, 'resume_playback') as mock_rpc:
+            assert provider.backend.supports_events
 
-        track_0 = TrackUri.from_track(playlist_item_mock, 0).uri
-        track_1 = TrackUri.from_track(playlist_item_mock, 1).uri
+            event = threading.Event()
 
-        process_click_mock = mock.PropertyMock()
+            def set_event():
+                event.set()
 
-        provider._double_click_handler.process_click = process_click_mock
-        provider._double_click_handler.set_click_time()
-        provider.active_track_uri = track_0
-        provider.change_track(models.Track(uri=track_1))
+            mock_rpc.side_effect = set_event
 
-        assert provider._double_click_handler.get_click_time() == 0
+            track_0 = TrackUri.from_track(playlist_item_mock, 0).uri
+            track_1 = TrackUri.from_track(playlist_item_mock, 1).uri
+
+            process_click_mock = mock.PropertyMock()
+
+            provider._double_click_handler.process_click = process_click_mock
+            provider._double_click_handler.set_click_time()
+            provider.active_track_uri = track_0
+
+            provider.change_track(models.Track(uri=track_1))
+
+        if event.wait(timeout=1.0):
+            mock_rpc.assert_called_once_with()
+        else:
+            assert False
 
 
-def test_change_track_resumes_playback(config, provider, playlist_item_mock):
+def test_change_track_does_not_resume_playback_if_not_doubleclick(provider, playlist_item_mock):
     with mock.patch.object(PandoraPlaybackProvider, 'change_track', return_value=True):
-        assert provider.backend.supports_events
+        with mock.patch.object(RPCClient, 'resume_playback') as mock_rpc:
+            assert provider.backend.supports_events
 
-        track_0 = TrackUri.from_track(playlist_item_mock, 0).uri
-        track_1 = TrackUri.from_track(playlist_item_mock, 1).uri
+            event = threading.Event()
 
-        process_click_mock = mock.PropertyMock()
+            def set_event():
+                event.set()
 
-        provider._double_click_handler.process_click = process_click_mock
-        provider.backend.rpc_client.resume_playback = mock.PropertyMock()
-        provider._double_click_handler.set_click_time()
-        provider.active_track_uri = track_0
-        provider.change_track(models.Track(uri=track_1))
+            mock_rpc.side_effect = set_event
 
-        provider.backend.rpc_client.resume_playback.assert_called_once_with()
+            track_0 = TrackUri.from_track(playlist_item_mock, 0).uri
+            track_1 = TrackUri.from_track(playlist_item_mock, 1).uri
+
+            process_click_mock = mock.PropertyMock()
+
+            provider._double_click_handler.process_click = process_click_mock
+            provider._double_click_handler.set_click_time(0)
+            provider.active_track_uri = track_0
+            provider.change_track(models.Track(uri=track_1))
+
+        if event.wait(timeout=1.0):
+            assert False
+        else:
+            assert not mock_rpc.called
 
 
 def test_is_playable_handles_request_exceptions(provider, caplog):
     with mock.patch.object(MopidyPandoraAPIClient, 'get_station', conftest.get_station_mock):
         with mock.patch.object(Station, 'get_playlist', conftest.get_station_playlist_mock):
             with mock.patch.object(PlaylistItem, 'get_is_playable', conftest.request_exception_mock):
-
                 track = models.Track(uri="pandora:track:test::::")
 
                 assert provider.change_track(track) is False
@@ -230,23 +234,107 @@ def test_is_playable_handles_request_exceptions(provider, caplog):
 
 
 def test_translate_uri_returns_audio_url(provider):
-
     assert provider.translate_uri("pandora:track:test:::::audio_url") == "audio_url"
 
 
-def test_auto_set_repeat_off_for_non_pandora_uri(provider):
-    with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
+def test_auto_setup_off_for_non_pandora_uri(provider):
+    with mock.patch.multiple('mopidy_pandora.rpc.RPCClient', set_repeat=mock.DEFAULT, set_random=mock.DEFAULT,
+                             set_consume=mock.DEFAULT) as values:
         with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="not_a_pandora_uri::::::"):
 
+            event = threading.Event()
+
+            def set_event():
+                event.set()
+
+            values['set_repeat'].side_effect = set_event
+
             provider.prepare_change()
 
-            assert not provider.backend.rpc_client.set_repeat.called
+            if event.wait(timeout=1.0):
+                assert False
+            else:
+                assert not values['set_repeat'].called
+                assert not values['set_random'].called
+                assert not values['set_consume'].called
 
 
-def test_auto_set_repeat_on_for_pandora_uri(provider):
-    with mock.patch.object(RPCClient, 'set_repeat', mock.Mock()):
+def test_auto_setup_on_for_pandora_uri(provider):
+    with mock.patch.multiple('mopidy_pandora.rpc.RPCClient', set_repeat=mock.DEFAULT, set_random=mock.DEFAULT,
+                             set_consume=mock.DEFAULT, set_single=mock.DEFAULT) as values:
+
         with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="pandora::::::"):
 
+            event = threading.Event()
+
+            def set_event():
+                event.set()
+
+            values['set_repeat'].side_effect = set_event
+
             provider.prepare_change()
 
-            provider.backend.rpc_client.set_repeat.assert_called_once_with()
+            if event.wait(timeout=1.0):
+                values['set_repeat'].assert_called_once_with()
+                values['set_random'].assert_called_once_with(False)
+                values['set_consume'].assert_called_once_with(False)
+                values['set_single'].assert_called_once_with(False)
+            else:
+                assert False
+
+
+def test_auto_setup_only_called_once(provider):
+    with mock.patch.multiple('mopidy_pandora.rpc.RPCClient', set_repeat=mock.DEFAULT, set_random=mock.DEFAULT,
+                             set_consume=mock.DEFAULT, set_single=mock.DEFAULT) as values:
+        with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="pandora::::::"):
+
+            event = threading.Event()
+
+            def set_event():
+                event.set()
+
+            values['set_repeat'].side_effect = set_event
+
+            provider.prepare_change()
+            provider.prepare_change()
+
+            if event.wait(timeout=1.0):
+                values['set_repeat'].assert_called_once_with()
+                values['set_random'].assert_called_once_with(False)
+                values['set_consume'].assert_called_once_with(False)
+                values['set_single'].assert_called_once_with(False)
+            else:
+                assert False
+
+
+def test_auto_setup_resets_for_non_pandora_tracks(provider):
+    with mock.patch.multiple('mopidy_pandora.rpc.RPCClient', set_repeat=mock.DEFAULT, set_random=mock.DEFAULT,
+                             set_consume=mock.DEFAULT, set_single=mock.DEFAULT) as values:
+        with mock.patch.object(RPCClient, 'get_current_track_uri', return_value="pandora::::::") as mock_get_uri:
+
+            event = threading.Event()
+
+            def set_event():
+                event.set()
+
+            values['set_repeat'].side_effect = set_event
+
+            provider.prepare_change()
+
+            if event.wait(timeout=1.0):
+                values['set_repeat'].assert_called_once_with()
+                values['set_random'].assert_called_once_with(False)
+                values['set_consume'].assert_called_once_with(False)
+                values['set_single'].assert_called_once_with(False)
+                assert not provider.backend.auto_setup
+            else:
+                assert False
+
+            mock_get_uri.return_value = "not_a_pandora_uri::::::"
+
+            provider.prepare_change()
+
+            if event.wait(timeout=1.0):
+                assert provider.backend.auto_setup
+            else:
+                assert False


### PR DESCRIPTION
There are two main enhancements / fixes in this PR:

**A. Resume playback after ratings are applied to a track**

Playback of the next track will now resume automatically after the user has triggered any of the available events using the 'double-click' functionality. In the past, one had to explicitly click on 'Play/Resume' again for the next track to play - this is no longer necessary.

**B. Move auto-set-repeat logic from Mopidy callback to a separate thread.**

This ensures that repeat mode is enabled as soon as the first Pandora track starts playing, rather than waiting for the callback in the last few seconds of the track.

Handles the usecase where the user clicks the back / next button before the end of the first track is reached.