### PR TITLE
Artist and album URI's should point back to the track URI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,13 @@ Changelog
 (UNRELEASED)
 ------------
 
+**Features and improvements**
+
 - Add support for searching. (Addresses: `#36 <https://github.com/rectalogic/mopidy-pandora/issues/36>`_).
+
+**Fixes**
+
+- Album and artist URIs now point back to the Pandora track. (Fixes: `#51 <https://github.com/rectalogic/mopidy-pandora/issues/51>`_).
 
 
 v0.2.2 (Apr 13, 2016)

--- a/mopidy_pandora/library.py
+++ b/mopidy_pandora/library.py
@@ -85,8 +85,6 @@ class PandoraLibraryProvider(backend.LibraryProvider):
                     if not track.company_name:
                         track.company_name = '(Company name not specified)'
                     album_kwargs['name'] = track.company_name
-
-                    album_kwargs['uri'] = track.click_through_url
                 else:
                     track_kwargs['name'] = track.song_name
                     track_kwargs['length'] = track.track_length * 1000
@@ -97,11 +95,12 @@ class PandoraLibraryProvider(backend.LibraryProvider):
                         pass
                     artist_kwargs['name'] = track.artist_name
                     album_kwargs['name'] = track.album_name
-                    album_kwargs['uri'] = track.album_detail_url
         else:
             raise ValueError('Unexpected type to perform Pandora track lookup: {}.'.format(pandora_uri.uri_type))
 
+        artist_kwargs['uri'] = uri  # Artist lookups should just point back to the track itself.
         track_kwargs['artists'] = [models.Artist(**artist_kwargs)]
+        album_kwargs['uri'] = uri   # Album lookups should just point back to the track itself.
         track_kwargs['album'] = models.Album(**album_kwargs)
         return [models.Track(**track_kwargs)]
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -197,6 +197,19 @@ def test_lookup_of_missing_track(config, playlist_item_mock, caplog):
     assert "Failed to lookup Pandora URI '{}'.".format(track_uri.uri) in caplog.text()
 
 
+def test_lookup_overrides_album_and_artist_uris(config, playlist_item_mock):
+    backend = conftest.get_backend(config)
+
+    track_uri = PlaylistItemUri._from_track(playlist_item_mock)
+    backend.library.pandora_track_cache[track_uri.uri] = TrackCacheItem(mock.Mock(spec=models.Ref.track),
+                                                                        playlist_item_mock)
+
+    results = backend.library.lookup(track_uri.uri)
+    track = results[0]
+    assert next(iter(track.artists)).uri == track_uri.uri
+    assert track.album.uri == track_uri.uri
+
+
 def test_browse_directory_uri(config):
     with mock.patch.object(APIClient, 'get_station_list', conftest.get_station_list_mock):
 


### PR DESCRIPTION
Looking up a specific artist or album by URI does not make sense in a Pandora context since we can only ever play stations based on those items.

This PR just ensures that the URIs point back to the track that they belong to, which should prevent undefined states from occurring in Mopidy frontend extensions (e.g. trying to do a Mopidy lookup of URL that points directly to a page on the Pandora server).