### PR TITLE
Allow station URI's to be added to playlists and the tracklist.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
 - Update documentation to refer to new 'Pandora Plus' subscription model instead of the old 'Pandora One'.
 - Update troubleshooting guide with more workarounds for cross-signed certificates using OpenSSL < 1.0.2.
+- Allow station URI's to be added to playlists and the Mopidy tracklist. (Addresses: `#58 <https://github.com/rectalogic/mopidy-pandora/issues/58>`_).
 
 v0.3.0 (Jul 8, 2016)
 --------------------

--- a/mopidy_pandora/playback.py
+++ b/mopidy_pandora/playback.py
@@ -7,7 +7,7 @@ from mopidy import backend
 import requests
 
 from mopidy_pandora import listener
-
+from mopidy_pandora.uri import PandoraUri, StationUri
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,14 @@ class PandoraPlaybackProvider(backend.PlaybackProvider):
     def change_track(self, track):
         if track.uri is None:
             logger.warning("No URI for Pandora track '{}'. Track cannot be played.".format(track))
+            return False
+
+        pandora_uri = PandoraUri.factory(track.uri)
+        if isinstance(pandora_uri, StationUri):
+            # Change to first track in station playlist.
+            logger.warning('Cannot play Pandora stations directly. Retrieving tracks for station with ID: {}...'
+                           .format(pandora_uri.station_id))
+            self.backend.end_of_tracklist_reached(station_id=pandora_uri.station_id, auto_play=True)
             return False
         try:
             self._trigger_track_changing(track)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ MOCK_STATION_ID = '0000000000000000001'
 MOCK_STATION_TOKEN = '0000000000000000001'
 MOCK_STATION_DETAIL_URL = 'http://mockup.com/station/detail_url?...'
 MOCK_STATION_ART_URL = 'http://mockup.com/station/art_url?...'
+MOCK_STATION_GENRE = 'Genre Mock'
 
 MOCK_STATION_LIST_CHECKSUM = 'aa00aa00aa00aa00aa00aa00aa00aa00'
 
@@ -105,7 +106,8 @@ def station_result_mock():
                         'stationDetailUrl': MOCK_STATION_DETAIL_URL,
                         'artUrl': MOCK_STATION_ART_URL,
                         'stationToken': MOCK_STATION_TOKEN,
-                        'stationName': MOCK_STATION_NAME},
+                        'stationName': MOCK_STATION_NAME,
+                        'genre': [MOCK_STATION_GENRE]},
                    }
 
     return mock_result

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -129,8 +129,8 @@ def test_lookup_of_invalid_uri_type(config, caplog):
     with pytest.raises(ValueError):
         backend = conftest.get_backend(config)
 
-        backend.library.lookup('pandora:station:mock_id:mock_token')
-        assert 'Unexpected type to perform Pandora track lookup: station.' in caplog.text()
+        backend.library.lookup('pandora:genre:mock_name')
+        assert 'Unexpected type to perform Pandora track lookup: genre.' in caplog.text()
 
 
 def test_lookup_of_ad_uri(config, ad_item_mock):
@@ -187,6 +187,23 @@ def test_lookup_of_search_uri(config, playlist_item_mock):
                 assert create_station_mock.called
                 # Check that the first track to be played is returned correctly.
                 assert results[0].uri == track_uri.uri
+
+
+def test_lookup_of_station_uri(config):
+    with mock.patch.object(MopidyAPIClient, 'get_station', conftest.get_station_mock):
+        with mock.patch.object(APIClient, 'get_station_list', conftest.get_station_list_mock):
+            backend = conftest.get_backend(config)
+
+            station_uri = PandoraUri.factory(conftest.station_mock())
+            results = backend.library.lookup(station_uri.uri)
+            assert len(results) == 1
+
+            track = results[0]
+            assert track.uri == station_uri.uri
+            assert next(iter(track.album.images)) == conftest.MOCK_STATION_ART_URL
+            assert track.name == conftest.MOCK_STATION_NAME
+            assert next(iter(track.artists)).name == 'Pandora Station'
+            assert track.album.name == conftest.MOCK_STATION_GENRE
 
 
 def test_lookup_of_track_uri(config, playlist_item_mock):

--- a/tests/test_playback.py
+++ b/tests/test_playback.py
@@ -117,6 +117,17 @@ def test_change_track_fetches_next_track_if_unplayable(provider, playlist_item_m
         assert 'Error changing Pandora track' in caplog.text()
 
 
+def test_change_track_fetches_next_track_if_station_uri(provider, caplog):
+    station = PandoraUri.factory(conftest.station_mock())
+
+    provider.backend._trigger_next_track_available = mock.PropertyMock()
+
+    assert provider.change_track(station) is False
+    assert 'Cannot play Pandora stations directly. Retrieving tracks for station with ID: {}...'.format(
+        station.station_id) in caplog.text()
+    assert provider.backend._trigger_next_track_available.called
+
+
 def test_change_track_skips_if_no_track_uri(provider):
     track = models.Track(uri=None)
 


### PR DESCRIPTION
Alternative to #59 that relies on the existing Mopidy-Pandora eventing framework for skipping over station URI's during playback, and retrieving the relevant track URI's instead.

Now also allows lookups to be performed on station URIs in order to retrieve station name and related information.

Addresses #58.